### PR TITLE
Message Flush functionality added and minor modifications to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,17 +21,15 @@ else ifeq ($(shell uname),Darwin)
  OSXOPTS = -undefined dynamic_lookup  -mmacosx-version-min=10.12
 endif
 
-KH = curl -s -O -J -L https://github.com/KxSystems/kdb/raw/master/c/c/k.h
-
 QARCH = $(OSFLAG)$(MS)
 Q     = $(QHOME)/$(QARCH) 
 
-all:
-	$(KH)
+all: k.h
 	$(CC) kfk.c -m$(MS) $(OPTS) $(LDOPTS_DYNAMIC) $(LD_COMMON) -I$(KFK_INCLUDE) $(LNK) -o $(TGT) $(OSXOPTS)
-static:
-	$(KH)
-	$(CC) kfk.c -m$(MS) $(OPTS) $(LDOPTS_STATIC)  $(LD_COMMON) -I$(KFK_INCLUDE) $(LNK) -o $(TGT) $(OSXOPTS) 
+static: k.h
+	$(CC) kfk.c -m$(MS) $(OPTS) $(LDOPTS_STATIC)  $(LD_COMMON) -I$(KFK_INCLUDE) $(LNK) -o $(TGT) $(OSXOPTS)
+k.h:
+	curl -s -O -J -L https://github.com/KxSystems/kdb/raw/master/c/c/k.h 
 install:
 	install $(TGT) $(Q)
 clean:

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ all: k.h
 static: k.h
 	$(CC) kfk.c -m$(MS) $(OPTS) $(LDOPTS_STATIC)  $(LD_COMMON) -I$(KFK_INCLUDE) $(LNK) -o $(TGT) $(OSXOPTS)
 k.h:
-	curl -s -O -J -L https://github.com/KxSystems/kdb/raw/master/c/c/k.h 
+	curl -s -O -L https://github.com/KxSystems/kdb/raw/master/c/c/k.h 
 install:
 	install $(TGT) $(Q)
 clean:

--- a/kfk.c
+++ b/kfk.c
@@ -357,13 +357,13 @@ EXP K2(kfkFlush){
   return KNL;
  if(!(rk= clientIndex(x)))
   return KNL;
-  SW(y->t){
-    CS(-KH,qy=y->h);
-    CS(-KI,qy=y->i);
-    CS(-KJ,qy=y->j);
-    CS(-KE,qy=y->e);
-    CD:R krr("timeout type");
-  }
+ SW(y->t){
+  CS(-KH,qy=y->h);
+  CS(-KI,qy=y->i);
+  CS(-KJ,qy=y->j);
+  CS(-KE,qy=y->e);
+  CD:R krr("timeout type");
+ }
  rd_kafka_resp_err_t err= rd_kafka_flush(rk,qy);
   if(KFK_OK != err)
     return krr((S) rd_kafka_err2str(err));

--- a/kfk.c
+++ b/kfk.c
@@ -352,11 +352,19 @@ rd_kafka_topic_partition_list_t* plistoffsetdict(S topic,K partitions){
 
 EXP K2(kfkFlush){
  rd_kafka_t *rk;
- if(!checkType("ii",x , y))
+ I qy;
+ if(!checkType("i",x))
   return KNL;
  if(!(rk= clientIndex(x)))
   return KNL;
- rd_kafka_resp_err_t err= rd_kafka_flush(rk,(I)y);
+  SW(y->t){
+    CS(-KH,qy=y->h);
+    CS(-KI,qy=y->i);
+    CS(-KJ,qy=y->j);
+    CS(-KE,qy=y->e);
+    CD:R krr("timeout type");
+  }
+ rd_kafka_resp_err_t err= rd_kafka_flush(rk,qy);
   if(KFK_OK != err)
     return krr((S) rd_kafka_err2str(err));
   return KNL;

--- a/kfk.c
+++ b/kfk.c
@@ -350,6 +350,18 @@ rd_kafka_topic_partition_list_t* plistoffsetdict(S topic,K partitions){
   return t_partition;
 }
 
+EXP K2(kfkFlush){
+ rd_kafka_t *rk;
+ if(!checkType("ii",x , y))
+  return KNL;
+ if(!(rk= clientIndex(x)))
+  return KNL;
+ rd_kafka_resp_err_t err= rd_kafka_flush(rk,(I)y);
+  if(KFK_OK != err)
+    return krr((S) rd_kafka_err2str(err));
+  return KNL;
+ }
+
 // producer api
 EXP K4(kfkPub){
   rd_kafka_topic_t *rkt;

--- a/kfk.c
+++ b/kfk.c
@@ -142,8 +142,7 @@ static K loadConf(rd_kafka_conf_t *conf, K x){
   char b[512];
   J i;
   for(i= 0; i < xx->n; ++i){
-    if(RD_KAFKA_CONF_OK !=
-       rd_kafka_conf_set(conf, kS(xx)[i], kS(xy)[i], b, sizeof(b))){
+    if(RD_KAFKA_CONF_OK !=rd_kafka_conf_set(conf, kS(xx)[i], kS(xy)[i], b, sizeof(b))){
       return krr((S) b);
     }
   }
@@ -351,20 +350,20 @@ rd_kafka_topic_partition_list_t* plistoffsetdict(S topic,K partitions){
 }
 
 EXP K2(kfkFlush){
- rd_kafka_t *rk;
- I qy;
- if(!checkType("i",x))
-  return KNL;
- if(!(rk= clientIndex(x)))
-  return KNL;
- SW(y->t){
-  CS(-KH,qy=y->h);
-  CS(-KI,qy=y->i);
-  CS(-KJ,qy=y->j);
-  CS(-KE,qy=y->e);
-  CD:R krr("timeout type");
- }
- rd_kafka_resp_err_t err= rd_kafka_flush(rk,qy);
+  rd_kafka_t *rk;
+  I qy;
+  if(!checkType("i",x))
+    return KNL;
+  if(!(rk= clientIndex(x)))
+    return KNL;
+  SW(y->t){
+    CS(-KH,qy=y->h);
+    CS(-KI,qy=y->i);
+    CS(-KJ,qy=y->j);
+    CS(-KE,qy=y->e);
+    CD:R krr("timeout type");
+  }
+  rd_kafka_resp_err_t err= rd_kafka_flush(rk,qy);
   if(KFK_OK != err)
     return krr((S) rd_kafka_err2str(err));
   return KNL;
@@ -485,20 +484,20 @@ EXP K3(kfkPositionOffsets){
 }
 
 EXP K1(kfkSubscription){
-	K r;
-	rd_kafka_topic_partition_list_t *t;
-	rd_kafka_t *rk;
-	rd_kafka_resp_err_t err;
-	if (!checkType("i", x))
-		return KNL;
-	if (!(rk = clientIndex(x)))
-		return KNL;
-	err = rd_kafka_subscription(rk, &t);
-	if (KFK_OK != err)
-		return krr((S)rd_kafka_err2str(err));
-	r = decodeParList(t);
-	rd_kafka_topic_partition_list_destroy(t);
-	return r;
+  K r;
+  rd_kafka_topic_partition_list_t *t;
+  rd_kafka_t *rk;
+  rd_kafka_resp_err_t err;
+  if (!checkType("i", x))
+    return KNL;
+  if (!(rk = clientIndex(x)))
+    return KNL;
+  err = rd_kafka_subscription(rk, &t);
+  if (KFK_OK != err)
+    return krr((S)rd_kafka_err2str(err));
+  r = decodeParList(t);
+  rd_kafka_topic_partition_list_destroy(t);
+  return r;
 }
 
 static J pu(J u){return 1000000LL*(u-10957LL*86400000LL);}

--- a/kfk.q
+++ b/kfk.q
@@ -35,6 +35,8 @@ funcs:(
 	(`kfkPoll;3);
 		// .kfk.Version[]:i
 	(`kfkVersion;1);
+		// .kfk.Flush[producer_id:i;timeout_ms:i]
+	(`kfkFlush;2);
 		// .kfk.ExportErr[]:T
 	(`kfkExportErr;1);
 	 // .kfk.CommitOffsets[client_id;topic:s;partition_offsets:I!J;async:b]:()


### PR DESCRIPTION
* Addition of function `.kfk.Flush` to ensure all outstanding messages have been sent to the broker. This is not called explicitely in pub as this would create a sync process. The function takes two arguments
1. Integer denoting the producer to apply the flush to.
2. Integer, long, int or short denoting the number of ms to wait for timeout.