### PR TITLE
Additional functionality and type checking update

### DIFF
--- a/kfk.c
+++ b/kfk.c
@@ -338,9 +338,6 @@ K decodeParList(rd_kafka_topic_partition_list_t *t){
 rd_kafka_topic_partition_list_t* plistoffsetdict(S topic,K partitions){
   K dk=kK(partitions)[0],dv=kK(partitions)[1];
   I*p;J*o,i;
-//  if(dk->n==0) return NULL; // empty dicts for offsetless commit
-  if(dk->n==0)
-    return(krr (S)"dictionary of zero length provided");
   p=kI(dk);o=kJ(dv);
   rd_kafka_topic_partition_list_t *t_partition=
       rd_kafka_topic_partition_list_new(dk->n);
@@ -427,6 +424,8 @@ EXP K3(kfkAssignOffsets){
   rd_kafka_resp_err_t err;
   if(!checkType("is!", x,y,z))
     return KNL;
+  if(!checkType("IJ",kK(z)[0],kK(z)[1]))
+    return KNL;
   if(!(rk= clientIndex(x)))
     return KNL;
   partitions = plistoffsetdict(y->s,z);
@@ -441,6 +440,8 @@ EXP K4(kfkCommitOffsets){
   rd_kafka_resp_err_t err;
   rd_kafka_t *rk;rd_kafka_topic_partition_list_t *t_partition;
   if(!checkType("is!b", x, y, z, r))
+    return KNL;
+  if(!checkType("IJ",kK(z)[0],kK(z)[1]))
     return KNL;
   if(!(rk= clientIndex(x)))
     return KNL;
@@ -459,6 +460,8 @@ EXP K3(kfkCommittedOffsets){
     return KNL;
   if(!(rk= clientIndex(x)))
     return KNL;
+  if(!checkType("IJ",kK(z)[0],kK(z)[1]))
+    return KNL;
   t_partition = plistoffsetdict(y->s,z);
   if(KFK_OK != (err= rd_kafka_committed(rk, t_partition,5000)))
     return krr((S) rd_kafka_err2str(err));
@@ -472,6 +475,8 @@ EXP K3(kfkPositionOffsets){
   rd_kafka_resp_err_t err;
   rd_kafka_t *rk;rd_kafka_topic_partition_list_t *t_partition;
   if(!checkType("is!", x, y, z))
+    return KNL;
+  if(!checkType("IJ",kK(z)[0],kK(z)[1]))
     return KNL;
   if(!(rk= clientIndex(x)))
     return KNL;

--- a/kfk.c
+++ b/kfk.c
@@ -560,7 +560,7 @@ EXP K1(kfkOutQLen){
   return ki(rd_kafka_outq_len(rk));
 }
 
-EXP K2(kfkPartition_Available){
+EXP K2(kfkPartitionAvailable){
   rd_kafka_topic_t *rkt;
   I qy=0;
   if(!checkType("[hij]",y))
@@ -576,7 +576,7 @@ EXP K2(kfkPartition_Available){
 }
 
 // logger level is set based on Severity levels in syslog https://en.wikipedia.org/wiki/Syslog#Severity_level
-EXP K2(kfkSet_Logger_Level){
+EXP K2(kfkSetLoggerLevel){
   rd_kafka_t *rk;
   I qy=0;
   if(!(rk=clientIndex(x)))
@@ -591,12 +591,12 @@ EXP K2(kfkSet_Logger_Level){
 }
 
 // Returns the number of threads currently being used by librdkafka
-EXP K kfkThread_Count(K UNUSED(x)){return ki(rd_kafka_thread_cnt());}
+EXP K kfkThreadCount(K UNUSED(x)){return ki(rd_kafka_thread_cnt());}
 
 EXP K kfkVersion(K UNUSED(x)){return ki(rd_kafka_version());}
 
 // Returns the human readable librdkafka version
-EXP K kfkVersion_String(K UNUSED(x)){return ks((S)rd_kafka_version_str());}
+EXP K kfkVersionSym(K UNUSED(x)){return ks((S)rd_kafka_version_str());}
 
 EXP K kfkExportErr(K UNUSED(dummy)){
   const struct rd_kafka_err_desc *errdescs;

--- a/kfk.c
+++ b/kfk.c
@@ -560,25 +560,12 @@ EXP K1(kfkOutQLen){
   return ki(rd_kafka_outq_len(rk));
 }
 
-EXP K2(kfkPartitionAvailable){
-  rd_kafka_topic_t *rkt;
-  I qy=0;
-  if(!checkType("[hij]",y))
-    return KNL;
-  if(!(rkt=topicIndex(x)))
-    return KNL;
-  SW(y->t){
-    CS(-KH,qy=y->h);
-    CS(-KI,qy=y->i);
-    CS(-KJ,qy=y->j);
-  }
-  return kb(rd_kafka_topic_partition_available(rkt, qy));
-}
-
 // logger level is set based on Severity levels in syslog https://en.wikipedia.org/wiki/Syslog#Severity_level
 EXP K2(kfkSetLoggerLevel){
   rd_kafka_t *rk;
   I qy=0;
+  if(!checkType("i[hij]",x,y))
+    return KNL;
   if(!(rk=clientIndex(x)))
     return KNL;
   SW(y->t){

--- a/kfk.c
+++ b/kfk.c
@@ -578,9 +578,15 @@ EXP K2(kfkPartition_Available){
 // logger level is set based on Severity levels in syslog https://en.wikipedia.org/wiki/Syslog#Severity_level
 EXP K2(kfkSet_Logger_Level){
   rd_kafka_t *rk;
+  I qy=0;
   if(!(rk=clientIndex(x)))
     return KNL;
-  rd_kafka_set_log_level(rk, y->i);
+  SW(y->t){
+    CS(-KH,qy=y->h);
+    CS(-KI,qy=y->i);
+    CS(-KJ,qy=y->j);
+  }
+  rd_kafka_set_log_level(rk, qy);
   return KNL;
 }
 

--- a/kfk.c
+++ b/kfk.c
@@ -338,7 +338,9 @@ K decodeParList(rd_kafka_topic_partition_list_t *t){
 rd_kafka_topic_partition_list_t* plistoffsetdict(S topic,K partitions){
   K dk=kK(partitions)[0],dv=kK(partitions)[1];
   I*p;J*o,i;
-  if(dk->n==0) return NULL; // empty dicts for offsetless commit
+//  if(dk->n==0) return NULL; // empty dicts for offsetless commit
+  if(dk->n==0)
+    return(krr (S)"dictionary of zero length provided");
   p=kI(dk);o=kJ(dv);
   rd_kafka_topic_partition_list_t *t_partition=
       rd_kafka_topic_partition_list_new(dk->n);
@@ -553,7 +555,37 @@ EXP K1(kfkOutQLen){
   return ki(rd_kafka_outq_len(rk));
 }
 
+EXP K2(kfkPartition_Available){
+  rd_kafka_topic_t *rkt;
+  I qy=0;
+  if(!checkType("[hij]",y))
+    return KNL;
+  if(!(rkt=topicIndex(x)))
+    return KNL;
+  SW(y->t){
+    CS(-KH,qy=y->h);
+    CS(-KI,qy=y->i);
+    CS(-KJ,qy=y->j);
+  }
+  return kb(rd_kafka_topic_partition_available(rkt, qy));
+}
+
+// logger level is set based on Severity levels in syslog https://en.wikipedia.org/wiki/Syslog#Severity_level
+EXP K2(kfkSet_Logger_Level){
+  rd_kafka_t *rk;
+  if(!(rk=clientIndex(x)))
+    return KNL;
+  rd_kafka_set_log_level(rk, y->i);
+  return KNL;
+}
+
+// Returns the number of threads currently being used by librdkafka
+EXP K kfkThread_Count(K UNUSED(x)){return ki(rd_kafka_thread_cnt());}
+
 EXP K kfkVersion(K UNUSED(x)){return ki(rd_kafka_version());}
+
+// Returns the human readable librdkafka version
+EXP K kfkVersion_String(K UNUSED(x)){return ks((S)rd_kafka_version_str());}
 
 EXP K kfkExportErr(K UNUSED(dummy)){
   const struct rd_kafka_err_desc *errdescs;

--- a/kfk.q
+++ b/kfk.q
@@ -45,8 +45,6 @@ funcs:(
 	(`kfkCommittedOffsets;3);
 	  // .kfk.AssignOffsets[client_id:i;topic:s;partition_offsets:I!J]:()
 	(`kfkAssignOffsets;3);
-          // .kfk.PartitionAvailable[topic_id:i]:i
-        (`kfkPartitionAvailable;2);
           // .kfk.Threadcount[]:i
         (`kfkThreadCount;1);
           // .kfk.VersionSym[]:s
@@ -67,9 +65,11 @@ Version:Version[];
 // Table with all errors return by kafka with codes and description
 Errors:ExportErr[];
 
+// projection function for handling int/long lists of partitions for offset functions
+osetp:{[cf;x;y;z]cf[x;y;$[99h=type z;z;("i"$z,())!count[z]#0]]}
 // Allow Offset functionality to take topics as a list in z argument
-CommittedOffsets:{[cf;x;y;z]cf[x;y;$[99h=type z;z;(z,())!count[z]#0]]}CommittedOffsets
-PositionOffsets:{[cf;x;y;z]cf[x;y;$[99h=type z;z;(z,())!count[z]#0]]}PositionOffsets
+CommittedOffsets:osetp[CommittedOffsets;;]
+PositionOffsets :osetp[PositionOffsets;;]
 
 // Unassigned partition.
 // The unassigned partition is used by the producer API for messages

--- a/kfk.q
+++ b/kfk.q
@@ -67,8 +67,9 @@ Version:Version[];
 // Table with all errors return by kafka with codes and description
 Errors:ExportErr[];
 
-// Allows .kfk.CommittedOffsets to take topics as a list in z argument
+// Allow Offset functionality to take topics as a list in z argument
 CommittedOffsets:{[cf;x;y;z]cf[x;y;$[99h=type z;z;(z,())!count[z]#0]]}CommittedOffsets
+PositionOffsets:{[cf;x;y;z]cf[x;y;$[99h=type z;z;(z,())!count[z]#0]]}PositionOffsets
 
 // Unassigned partition.
 // The unassigned partition is used by the producer API for messages

--- a/kfk.q
+++ b/kfk.q
@@ -51,10 +51,9 @@ funcs:(
         (`kfkThread_Count;1);
           // .kfk.Version_str[]:s
         (`kfkVersion_String;1);
-          // .kfk.Set_Logger_Level[int_level:i]:()
+          // .kfk.Set_Logger_Level[client_id:i;int_level:i]:()
         (`kfkSet_Logger_Level;2)
 	);
-
 
 // binding functions from dictionary funcs using rule
 // kfk<Name> -> .kfk.<Name>
@@ -67,6 +66,9 @@ Version:Version[];
 
 // Table with all errors return by kafka with codes and description
 Errors:ExportErr[];
+
+// Allows .kfk.CommittedOffsets to take topics as a list in z argument
+CommittedOffsets:{[cf;x;y;z]cf[x;y;$[99h=type z;z;(z,())!count[z]#0]]}CommittedOffsets
 
 // Unassigned partition.
 // The unassigned partition is used by the producer API for messages

--- a/kfk.q
+++ b/kfk.q
@@ -1,52 +1,58 @@
 \d .kfk
 LIBPATH:`:libkfk 2:
 funcs:(
-		// .kfk.init[]:i
+	  // .kfk.init[]:i
 	(`kfkInit;1);
-		// .kfk.Client[client_type:c;conf:S!S]:i
+	  // .kfk.Client[client_type:c;conf:S!S]:i
 	(`kfkClient;2);
-		// .kfk.ClientDel[client_id:i]:_
+	  // .kfk.ClientDel[client_id:i]:_
 	(`kfkClientDel;1);
-		// .kfk.ClientName[client_id:i]:s
+	  // .kfk.ClientName[client_id:i]:s
 	(`kfkClientName;1);
-		// .kfk.ClientMemberId[client_id:i]:s
+	  // .kfk.ClientMemberId[client_id:i]:s
 	(`kfkClientMemberId;1);
-		// .kfk.Topic[client_id:i;topicname:s;conf:S!S]:i
+	  // .kfk.Topic[client_id:i;topicname:s;conf:S!S]:i
 	(`kfkTopic;3);
-		// .kfk.TopicDel[topic_id:i]:_
+	  // .kfk.TopicDel[topic_id:i]:_
 	(`kfkTopicDel;1);
-		// .kfk.TopicName[topic_id:i]:s
+	  // .kfk.TopicName[topic_id:i]:s
 	(`kfkTopicName;1);
-		// .kfk.Metadata[client_id:i]:S!()
+	  // .kfk.Metadata[client_id:i]:S!()
 	(`kfkMetadata;1);
-	// PRODUCER API
-		// .kfk.Pub[topic_id:i;partid:i;data;key]:_
+	  // .kfk.Pub[topic_id:i;partid:i;data;key]:_
 	(`kfkPub;4);
-		// .kfk.OutQLen[client_id:i]:i
+	  // .kfk.OutQLen[client_id:i]:i
 	(`kfkOutQLen;1);
-	// CONSUMER API
-		// .kfk.Sub[client_id:i;topicname:s;partition_list|partition_offsets:I!J]:()
+	  // .kfk.Sub[client_id:i;topicname:s;partition_list|partition_offsets:I!J]:()
 	(`kfkSub;3);
-		// .kfk.Unsub[client_id:i]:()
+	  // .kfk.Unsub[client_id:i]:()
 	(`kfkUnsub;1);
-		// .kfk.Subscription[client_id:i]
+	  // .kfk.Subscription[client_id:i]
 	(`kfkSubscription;1);
-		// .kfk.Poll[client_id:i;timeout;max_messages]
+	  // .kfk.Poll[client_id:i;timeout;max_messages]
 	(`kfkPoll;3);
-		// .kfk.Version[]:i
+	  // .kfk.Version[]:i
 	(`kfkVersion;1);
-		// .kfk.Flush[producer_id:i;timeout_ms:i]
+	  // .kfk.Flush[producer_id:i;timeout_ms:i]:()
 	(`kfkFlush;2);
-		// .kfk.ExportErr[]:T
+	  // .kfk.ExportErr[]:T
 	(`kfkExportErr;1);
-	 // .kfk.CommitOffsets[client_id;topic:s;partition_offsets:I!J;async:b]:()
+	  // .kfk.CommitOffsets[client_id;topic:s;partition_offsets:I!J;async:b]:()
 	(`kfkCommitOffsets;4);
-	 // .kfk.PositionOffsets[client_id:i;topic:s;partition_offsets:I!J]:partition_offsets
+	  // .kfk.PositionOffsets[client_id:i;topic:s;partition_offsets:I!J]:partition_offsets
 	(`kfkPositionOffsets;3);
-	 // .kfk.CommittedOffsets[client_id:i;topic:s;partition_offsets:I!J]:partition_offsets
+	  // .kfk.CommittedOffsets[client_id:i;topic:s;partition_offsets:I!J]:partition_offsets
 	(`kfkCommittedOffsets;3);
-	 // .kfk.AssignOffsets[client_id:i;topic:s;partition_offsets:I!J]:()
-	(`kfkAssignOffsets;3)
+	  // .kfk.AssignOffsets[client_id:i;topic:s;partition_offsets:I!J]:()
+	(`kfkAssignOffsets;3);
+          // .kfk.Partition_Available[topic_id:i]:i
+        (`kfkPartition_Available;2);
+          // .kfk.Thread_count[]:i
+        (`kfkThread_Count;1);
+          // .kfk.Version_str[]:s
+        (`kfkVersion_String;1);
+          // .kfk.Set_Logger_Level[int_level:i]:()
+        (`kfkSet_Logger_Level;2)
 	);
 
 

--- a/kfk.q
+++ b/kfk.q
@@ -45,14 +45,14 @@ funcs:(
 	(`kfkCommittedOffsets;3);
 	  // .kfk.AssignOffsets[client_id:i;topic:s;partition_offsets:I!J]:()
 	(`kfkAssignOffsets;3);
-          // .kfk.Partition_Available[topic_id:i]:i
-        (`kfkPartition_Available;2);
-          // .kfk.Thread_count[]:i
-        (`kfkThread_Count;1);
-          // .kfk.Version_str[]:s
-        (`kfkVersion_String;1);
-          // .kfk.Set_Logger_Level[client_id:i;int_level:i]:()
-        (`kfkSet_Logger_Level;2)
+          // .kfk.PartitionAvailable[topic_id:i]:i
+        (`kfkPartitionAvailable;2);
+          // .kfk.Threadcount[]:i
+        (`kfkThreadCount;1);
+          // .kfk.VersionSym[]:s
+        (`kfkVersionSym;1);
+          // .kfk.SetLoggerLevel[client_id:i;int_level:i]:()
+        (`kfkSetLoggerLevel;2)
 	);
 
 // binding functions from dictionary funcs using rule


### PR DESCRIPTION
Following functions give greater exposer to librdkafka API functions:

```
// Human readable output denoting the version of librdkafka being used
1.  .kfk.Version_String[]:s

// Current number of threads being used by librdkafka
2.  .kfk.Thread_Count[]:i

// set logging severity for a particular client 
//https://en.wikipedia.org/wiki/Syslog#Severity_level
3.  .kfk.Set_Logger_Level[client_id:int ;severity_level:int/short/long]:()
```

`.kfk.CommittedOffsets` and `.kfk.PositionOffsets` will now take a list of integer partitions for a given topic to query as third argument in addition to the dictionary it had been working with

Increased type checking of dictionary elements in offset functionality and removal of potential segfault on passing of empty dictionary.