### PR TITLE
Addition of multi-subscription call functionality

### DIFF
--- a/examples/test_consumer.q
+++ b/examples/test_consumer.q
@@ -8,13 +8,18 @@ kfk_cfg:(!) . flip(
     (`statistics.interval.ms;`10000)
     );
 client:.kfk.Consumer[kfk_cfg];
+
 data:();
 .kfk.consumecb:{[msg]
     msg[`data]:"c"$msg[`data];
     msg[`rcvtime]:.z.p;
     data,::enlist msg;}
 
-.kfk.Sub[client;`test;enlist .kfk.PARTITION_UA];
+// Topics to subscribe to
+topic1:`test1; topic2:`test2;
+
+// Subscribe to multiple topics from a single client
+.kfk.Sub[client;;enlist .kfk.PARTITION_UA]each(topic1;topic2);
 
 client_meta:.kfk.Metadata[client];
 show client_meta`topics;

--- a/examples/test_offsetc.q
+++ b/examples/test_offsetc.q
@@ -36,7 +36,7 @@ strt:.z.t
 .z.ts:{n+:1;topic:$[n mod 2;topic1;topic2];
   if[(5000<"i"$.z.t-strt)&1<count data;
     -1 "\nPublishing information from topic :",string topic;
-    seen:exec last offset by partition from data;
+    show seen:exec last offset by partition from data where topic=topic;
     show "Position:";
     show .kfk.PositionOffsets[client;topic;seen];
     show "Before commited:";

--- a/examples/test_offsetp.q
+++ b/examples/test_offsetp.q
@@ -6,14 +6,22 @@ kfk_cfg:(!) . flip(
   (`fetch.wait.max.ms;`10)
   );
 producer:.kfk.Producer[kfk_cfg]
-test_topic:.kfk.Topic[producer;`test;()!()]
 
+// Create two topics associated with the producer publishing on `test1`test2
+topic1:.kfk.Topic[producer;`test1;()!()]
+topic2:.kfk.Topic[producer;`test2;()!()]
+
+// Define a delivery callback
 .kfk.drcb:{[cid;msg]show "Delivered msg on ",string[cid],": ",.Q.s1 msg;}
 
+// Publish messages at different rates
+.z.ts:{n+:1;
+       .kfk.Pub[topic1;0i;string x;""];
+       if[n mod 2;.kfk.Pub[topic2;0i;string x;""]]}
+-1 "Publishing on topics:", " "sv{string .kfk.TopicName x}each(topic1;topic2);
+.kfk.Pub[topic1;0i;string .z.p;""];
+.kfk.Pub[topic2;0i;string .z.p;""];
 
-.z.ts:{.kfk.Pub[test_topic;0i;string x;""]}
-show "Publishing on topic:",string .kfk.TopicName test_topic;
-.kfk.Pub[test_topic;0i;string .z.p;""];
-show "Published 1 message";
-show "Set timer with \t 1000 to publish message every second";
+-1 "Published one message to each topic.\n";
+-1"Set timer with \\t 1000 to publish a message on `test1 every second and on `test2 every two seconds.";
 

--- a/examples/test_producer.q
+++ b/examples/test_producer.q
@@ -7,13 +7,18 @@ kfk_cfg:(!) . flip(
   );
 producer:.kfk.Producer[kfk_cfg]
 
-test_topic:.kfk.Topic[producer;`test;()!()]
+topic1:.kfk.Topic[producer;`test1;()!()]
+topic2:.kfk.Topic[producer;`test2;()!()]
 
-.z.ts:{.kfk.Pub[test_topic;.kfk.PARTITION_UA;string x;""]}
-show "Publishing on topic:",string .kfk.TopicName test_topic;
-.kfk.Pub[test_topic;.kfk.PARTITION_UA;string .z.p;""];
-show "Published 1 message";
+.z.ts:{n+:1;topic:$[n mod 2;topic1;topic2];
+       .kfk.Pub[topic;.kfk.PARTITION_UA;string x;""]}
+
+
+
+-1 "Publishing on topics:",string[.kfk.TopicName topic1],", ",string[.kfk.TopicName topic2];
+.kfk.Pub[;.kfk.PARTITION_UA;string .z.p;""]each(topic1;topic2);
+-1 "Published one message for each topic";
 producer_meta:.kfk.Metadata[producer];
 show producer_meta`topics;
-show "Set timer with \t 1000 to publish message every second";
+-1 "Set timer with \\t 500 to publish a message each second to each topic.";
 

--- a/kfk.c
+++ b/kfk.c
@@ -387,9 +387,9 @@ EXP K4(kfkPub){
 EXP K3(kfkSub){
   rd_kafka_resp_err_t err;
   rd_kafka_t *rk;rd_kafka_topic_partition_list_t *t_partition;
-  J i;
+  J i,j;
   I*p;
-  if(!checkType("is[I!]", x, y, z))
+  if(!checkType("i[sS][I!]", x, y, z))
     return KNL;
   if(!(rk= clientIndex(x)))
     return KNL;
@@ -401,7 +401,13 @@ EXP K3(kfkSub){
       rd_kafka_topic_partition_list_new(z->n);
     for(i= 0; i < z->n; ++i){
       p=kI(z);
-      rd_kafka_topic_partition_list_add(t_partition, y->s, p[i]);
+      if(y->t == -KS)
+        rd_kafka_topic_partition_list_add(t_partition, y->s, p[i]);
+      else{
+        for(j=0;j < y->n; ++j){
+          rd_kafka_topic_partition_list_add(t_partition, kS(y)[j], p[i]);
+        }
+      }
     }
   }
   if(KFK_OK != (err= rd_kafka_subscribe(rk, t_partition)))

--- a/kfk.c
+++ b/kfk.c
@@ -130,6 +130,10 @@ static V offsetcb(rd_kafka_t *rk, rd_kafka_resp_err_t err,rd_kafka_topic_partiti
   printr0(k(0, (S) ".kfk.offsetcb", ki(indexClient(rk)), kp((S)rd_kafka_err2str(err)), decodeParList(offsets),KNL));
 }
 
+static V thrcb(rd_kafka_t *rk, const char *broker_name, int32_t broker_id, int throttle_time_ms, void *UNUSED(opaque)){
+  printr0(k(0, (S) ".kfk.throttlecb",ki(indexClient(rk)),kp((S)broker_name),ki(broker_id),ki(throttle_time_ms),KNL));
+}
+
 K decodeMsg(const rd_kafka_t*rk,const rd_kafka_message_t *msg);
 
 static V drcb(rd_kafka_t*rk,const rd_kafka_message_t *msg,V*UNUSED(opaque)){
@@ -176,6 +180,7 @@ EXP K2(kfkClient){
   rd_kafka_conf_set_log_cb(conf, logcb);
   rd_kafka_conf_set_dr_msg_cb(conf,drcb);
   rd_kafka_conf_set_offset_commit_cb(conf,offsetcb);
+  rd_kafka_conf_set_throttle_cb(conf, thrcb);
   if(RD_KAFKA_CONF_OK !=rd_kafka_conf_set(conf, "log.queue", "true", b, sizeof(b)))
     return krr((S) b);
   if(!(rk= rd_kafka_new(type, conf, b, sizeof(b))))
@@ -610,6 +615,7 @@ EXP K kfkCallback(I d){
     pollClient((rd_kafka_t*)kS(clients)[i], 0, consumed);
   return KNL;
 }
+
 
 static V detach(V){
   I sp,i;

--- a/kfk.c
+++ b/kfk.c
@@ -130,10 +130,6 @@ static V offsetcb(rd_kafka_t *rk, rd_kafka_resp_err_t err,rd_kafka_topic_partiti
   printr0(k(0, (S) ".kfk.offsetcb", ki(indexClient(rk)), kp((S)rd_kafka_err2str(err)), decodeParList(offsets),KNL));
 }
 
-static V thrcb(rd_kafka_t *rk, const char *broker_name, int32_t broker_id, int throttle_time_ms, void *UNUSED(opaque)){
-  printr0(k(0, (S) ".kfk.throttlecb",ki(indexClient(rk)),kp((S)broker_name),ki(broker_id),ki(throttle_time_ms),KNL));
-}
-
 K decodeMsg(const rd_kafka_t*rk,const rd_kafka_message_t *msg);
 
 static V drcb(rd_kafka_t*rk,const rd_kafka_message_t *msg,V*UNUSED(opaque)){
@@ -180,7 +176,6 @@ EXP K2(kfkClient){
   rd_kafka_conf_set_log_cb(conf, logcb);
   rd_kafka_conf_set_dr_msg_cb(conf,drcb);
   rd_kafka_conf_set_offset_commit_cb(conf,offsetcb);
-  rd_kafka_conf_set_throttle_cb(conf, thrcb);
   if(RD_KAFKA_CONF_OK !=rd_kafka_conf_set(conf, "log.queue", "true", b, sizeof(b)))
     return krr((S) b);
   if(!(rk= rd_kafka_new(type, conf, b, sizeof(b))))

--- a/kfk.c
+++ b/kfk.c
@@ -386,18 +386,16 @@ EXP K3(kfkSub){
     return KNL;
   if(!(rk= clientIndex(x)))
     return KNL;
-  err = rd_kafka_subscription(rk, &t_partition);
-  if(KFK_OK != err)
+  if(KFK_OK != (err = rd_kafka_subscription(rk, &t_partition)))
     return krr((S)rd_kafka_err2str(err));
   if(z->t == XD){
     if(!checkType("IJ", kK(z)[0], kK(z)[1]))
       return KNL;
     plistoffsetdict(y->s,z,t_partition);
   }
-  else{
+  else
     for(p=kI(z), i= 0; i < z->n; ++i)
       rd_kafka_topic_partition_list_add(t_partition, y->s, p[i]);
-  }
   if(KFK_OK != (err= rd_kafka_subscribe(rk, t_partition)))
     return krr((S) rd_kafka_err2str(err));
   rd_kafka_topic_partition_list_destroy(t_partition);
@@ -420,7 +418,7 @@ EXP K1(kfkUnsub){
 // https://github.com/edenhill/librdkafka/wiki/Manually-setting-the-consumer-start-offset
 EXP K3(kfkAssignOffsets){
   rd_kafka_t *rk;
-  rd_kafka_topic_partition_list_t *partitions;
+  rd_kafka_topic_partition_list_t *t_partition;
   rd_kafka_resp_err_t err;
   if(!checkType("is!", x,y,z))
     return KNL;
@@ -428,12 +426,12 @@ EXP K3(kfkAssignOffsets){
     return KNL;
   if(!(rk= clientIndex(x)))
     return KNL;
-  rd_kafka_subscription(rk,&partitions);
-  plistoffsetdict(y->s,z,partitions);
-  err=rd_kafka_assign(rk, partitions);
+  t_partition = rd_kafka_topic_partition_list_new(z->n);
+  plistoffsetdict(y->s,z,t_partition);
+  err=rd_kafka_assign(rk,t_partition);
   if(KFK_OK != err)
     return krr((S) rd_kafka_err2str(err));
-  rd_kafka_topic_partition_list_destroy(partitions); 
+  rd_kafka_topic_partition_list_destroy(t_partition);
   return knk(0);
 }
 
@@ -445,8 +443,8 @@ EXP K4(kfkCommitOffsets){
   if(!checkType("IJ",kK(z)[0],kK(z)[1]))
     return KNL;
   if(!(rk= clientIndex(x)))
-    return KNL;
-  rd_kafka_subscription(rk,&t_partition);
+    return KNL;  
+  t_partition = rd_kafka_topic_partition_list_new(z->n);
   plistoffsetdict(y->s,z,t_partition);
   if(KFK_OK != (err= rd_kafka_commit(rk, t_partition,r->g)))
     return krr((S) rd_kafka_err2str(err));
@@ -464,7 +462,7 @@ EXP K3(kfkCommittedOffsets){
     return KNL;
   if(!checkType("IJ",kK(z)[0],kK(z)[1]))
     return KNL;
-  rd_kafka_subscription(rk,&t_partition);
+  t_partition = rd_kafka_topic_partition_list_new(z->n);
   plistoffsetdict(y->s,z,t_partition);
   if(KFK_OK != (err= rd_kafka_committed(rk, t_partition,5000)))
     return krr((S) rd_kafka_err2str(err));
@@ -483,8 +481,8 @@ EXP K3(kfkPositionOffsets){
     return KNL;
   if(!(rk= clientIndex(x)))
     return KNL;
-  rd_kafka_subscription(rk,&t_partition);
-  plistoffsetdict(y->s,z,t_partition);
+  t_partition = rd_kafka_topic_partition_list_new(z->n);
+  plistoffsetdict(y->s,z,t_partition); 
   if(KFK_OK != (err= rd_kafka_position(rk, t_partition)))
     return krr((S) rd_kafka_err2str(err));
   r=decodeParList(t_partition);

--- a/kfk.c
+++ b/kfk.c
@@ -335,7 +335,8 @@ K decodeParList(rd_kafka_topic_partition_list_t *t){
   return r;
 }
 
-rd_kafka_topic_partition_list_t* plistoffsetdict(S topic,K partitions,rd_kafka_topic_partition_list_t *t_partition){
+
+static V plistoffsetdict(S topic,K partitions,rd_kafka_topic_partition_list_t *t_partition){
   K dk=kK(partitions)[0],dv=kK(partitions)[1];
   I*p;J*o,i;
   p=kI(dk);o=kJ(dv);
@@ -343,7 +344,6 @@ rd_kafka_topic_partition_list_t* plistoffsetdict(S topic,K partitions,rd_kafka_t
     rd_kafka_topic_partition_list_add(t_partition, topic, p[i]);
     rd_kafka_topic_partition_list_set_offset(t_partition, topic, p[i],o[i]);
   }
-  return t_partition;
 }
 
 EXP K2(kfkFlush){
@@ -390,13 +390,13 @@ EXP K3(kfkSub){
   if(KFK_OK != err)
     return krr((S)rd_kafka_err2str(err));
   if(z->t == XD){
-    t_partition = plistoffsetdict(y->s,z,t_partition);
+    if(!checkType("IJ", kK(z)[0], kK(z)[1]))
+      return KNL;
+    plistoffsetdict(y->s,z,t_partition);
   }
   else{
-    p=kI(z);
-    for(i= 0; i < z->n; ++i){
+    for(p=kI(z), i= 0; i < z->n; ++i)
       rd_kafka_topic_partition_list_add(t_partition, y->s, p[i]);
-    }
   }
   if(KFK_OK != (err= rd_kafka_subscribe(rk, t_partition)))
     return krr((S) rd_kafka_err2str(err));
@@ -429,7 +429,7 @@ EXP K3(kfkAssignOffsets){
   if(!(rk= clientIndex(x)))
     return KNL;
   rd_kafka_subscription(rk,&partitions);
-  partitions = plistoffsetdict(y->s,z,partitions);
+  plistoffsetdict(y->s,z,partitions);
   err=rd_kafka_assign(rk, partitions);
   if(KFK_OK != err)
     return krr((S) rd_kafka_err2str(err));
@@ -447,7 +447,7 @@ EXP K4(kfkCommitOffsets){
   if(!(rk= clientIndex(x)))
     return KNL;
   rd_kafka_subscription(rk,&t_partition);
-  t_partition = plistoffsetdict(y->s,z,t_partition);
+  plistoffsetdict(y->s,z,t_partition);
   if(KFK_OK != (err= rd_kafka_commit(rk, t_partition,r->g)))
     return krr((S) rd_kafka_err2str(err));
   rd_kafka_topic_partition_list_destroy(t_partition);
@@ -465,7 +465,7 @@ EXP K3(kfkCommittedOffsets){
   if(!checkType("IJ",kK(z)[0],kK(z)[1]))
     return KNL;
   rd_kafka_subscription(rk,&t_partition);
-  t_partition = plistoffsetdict(y->s,z,t_partition);
+  plistoffsetdict(y->s,z,t_partition);
   if(KFK_OK != (err= rd_kafka_committed(rk, t_partition,5000)))
     return krr((S) rd_kafka_err2str(err));
   r=decodeParList(t_partition);
@@ -484,7 +484,7 @@ EXP K3(kfkPositionOffsets){
   if(!(rk= clientIndex(x)))
     return KNL;
   rd_kafka_subscription(rk,&t_partition);
-  t_partition = plistoffsetdict(y->s,z,t_partition);
+  plistoffsetdict(y->s,z,t_partition);
   if(KFK_OK != (err= rd_kafka_position(rk, t_partition)))
     return krr((S) rd_kafka_err2str(err));
   r=decodeParList(t_partition);
@@ -501,8 +501,7 @@ EXP K1(kfkSubscription){
     return KNL;
   if (!(rk = clientIndex(x)))
     return KNL;
-  err = rd_kafka_subscription(rk, &t);
-  if (KFK_OK != err)
+  if (KFK_OK != (err= rd_kafka_subscription(rk, &t)))
     return krr((S)rd_kafka_err2str(err));
   r = decodeParList(t);
   rd_kafka_topic_partition_list_destroy(t);

--- a/kfk.c
+++ b/kfk.c
@@ -428,8 +428,7 @@ EXP K3(kfkAssignOffsets){
     return KNL;
   t_partition = rd_kafka_topic_partition_list_new(z->n);
   plistoffsetdict(y->s,z,t_partition);
-  err=rd_kafka_assign(rk,t_partition);
-  if(KFK_OK != err)
+  if(KFK_OK != (err=rd_kafka_assign(rk,t_partition)))
     return krr((S) rd_kafka_err2str(err));
   rd_kafka_topic_partition_list_destroy(t_partition);
   return knk(0);

--- a/kfk.q
+++ b/kfk.q
@@ -114,7 +114,4 @@ offsetcb:{[cid;err;offsets]}
 // Main callback for consuming messages(including errors)
 consumecb:{[msg]}
 
-// Throttle callback call to(rd_kafka_conf_set_throttle_cb)
-throttlecb:{[cid;bname;bif;throttle]}
-
 \d .

--- a/kfk.q
+++ b/kfk.q
@@ -114,4 +114,7 @@ offsetcb:{[cid;err;offsets]}
 // Main callback for consuming messages(including errors)
 consumecb:{[msg]}
 
+// Throttle callback call to(rd_kafka_conf_set_throttle_cb)
+throttlecb:{[cid;bname;bif;throttle]}
+
 \d .


### PR DESCRIPTION
Update to subscription functionality to incorporate the following changes

* Consumer clients can now handle multiple calls to `.kfk.Sub` thus allowing consumption from multiple topics, this works for both the offset and non-offset functionality
* Update to example scripts to incorporate the multiple subscription functionality and improve general readability.