### PR TITLE
Subscriptions to multiple topics from a single client

### DIFF
--- a/examples/test_consumer.q
+++ b/examples/test_consumer.q
@@ -8,13 +8,18 @@ kfk_cfg:(!) . flip(
     (`statistics.interval.ms;`10000)
     );
 client:.kfk.Consumer[kfk_cfg];
+
 data:();
 .kfk.consumecb:{[msg]
     msg[`data]:"c"$msg[`data];
     msg[`rcvtime]:.z.p;
     data,::enlist msg;}
 
-.kfk.Sub[client;`test;enlist .kfk.PARTITION_UA];
+// Topics to subscribe to
+topic1:`test1; topic2:`test2;
+
+// Subscribe to multiple topics from a single client
+.kfk.Sub[client;;enlist .kfk.PARTITION_UA]each(topic1;topic2);
 
 client_meta:.kfk.Metadata[client];
 show client_meta`topics;

--- a/examples/test_offsetc.q
+++ b/examples/test_offsetc.q
@@ -10,29 +10,38 @@ kfk_cfg:(!) . flip(
     (`enable.auto.offset.store;`false)
     );
 client:.kfk.Consumer[kfk_cfg];
-TOPIC:`test
+
+// Topics to be published to
+topic1:`test1
+topic2:`test2
 data:();
+
+// Callback function for managing of messages
 .kfk.consumecb:{[msg]
     msg[`data]:"c"$msg[`data];
     msg[`rcvtime]:.z.p;
     data,::enlist msg;}
+// Define Offset callback functionality
 .kfk.offsetcb:{[cid;err;offsets]show (cid;err;offsets);}
 
-
-show .kfk.AssignOffsets[client;TOPIC;(1#0i)!1#.kfk.OFFSET.END]     // start replaying from the end
-.kfk.Sub[client;TOPIC;(1#0i)!1#.kfk.OFFSET.END];
-
+// Assign partitions to consume from specified offsets
+show .kfk.AssignOffsets[client;;(1#0i)!1#.kfk.OFFSET.END]each (topic1;topic2)
+// Subscribe to relevant topics from a defined client
+.kfk.Sub[client;;(1#0i)!1#.kfk.OFFSET.END]each (topic1;topic2)
 
 strt:.z.t
+// The following example has been augmented to display and commit offsets for each of
+// the available topics every 10 seconds
 \t 5000
-.z.ts:{
+.z.ts:{n+:1;topic:$[n mod 2;topic1;topic2];
   if[(5000<"i"$.z.t-strt)&1<count data;
-  seen:exec last offset by partition from data;
-  show "Position:";
-  show .kfk.PositionOffsets[client;TOPIC;seen];
-  show "Before commited:";
-  show .kfk.CommittedOffsets[client;TOPIC;seen];
-  .kfk.CommitOffsets[client;TOPIC;seen;0b];  // commit whatever is storred
-  show "After commited:";
-  show .kfk.CommittedOffsets[client;TOPIC;seen];]
+    -1 "\nPublishing information from topic :",string topic;
+    show seen:exec last offset by partition from data where topic=topic;
+    show "Position:";
+    show .kfk.PositionOffsets[client;topic;seen];
+    show "Before commited:";
+    show .kfk.CommittedOffsets[client;topic;seen];
+    .kfk.CommitOffsets[client;topic;seen;0b];
+    show "After commited:";
+    show .kfk.CommittedOffsets[client;topic;seen];]
   }

--- a/examples/test_offsetp.q
+++ b/examples/test_offsetp.q
@@ -6,14 +6,22 @@ kfk_cfg:(!) . flip(
   (`fetch.wait.max.ms;`10)
   );
 producer:.kfk.Producer[kfk_cfg]
-test_topic:.kfk.Topic[producer;`test;()!()]
 
+// Create two topics associated with the producer publishing on `test1`test2
+topic1:.kfk.Topic[producer;`test1;()!()]
+topic2:.kfk.Topic[producer;`test2;()!()]
+
+// Define a delivery callback
 .kfk.drcb:{[cid;msg]show "Delivered msg on ",string[cid],": ",.Q.s1 msg;}
 
+// Publish messages at different rates
+.z.ts:{n+:1;
+       .kfk.Pub[topic1;0i;string x;""];
+       if[n mod 2;.kfk.Pub[topic2;0i;string x;""]]}
+-1 "Publishing on topics:", " "sv{string .kfk.TopicName x}each(topic1;topic2);
+.kfk.Pub[topic1;0i;string .z.p;""];
+.kfk.Pub[topic2;0i;string .z.p;""];
 
-.z.ts:{.kfk.Pub[test_topic;0i;string x;""]}
-show "Publishing on topic:",string .kfk.TopicName test_topic;
-.kfk.Pub[test_topic;0i;string .z.p;""];
-show "Published 1 message";
-show "Set timer with \t 1000 to publish message every second";
+-1 "Published one message to each topic.\n";
+-1"Set timer with \\t 1000 to publish a message on `test1 every second and on `test2 every two seconds.";
 

--- a/examples/test_producer.q
+++ b/examples/test_producer.q
@@ -7,13 +7,18 @@ kfk_cfg:(!) . flip(
   );
 producer:.kfk.Producer[kfk_cfg]
 
-test_topic:.kfk.Topic[producer;`test;()!()]
+topic1:.kfk.Topic[producer;`test1;()!()]
+topic2:.kfk.Topic[producer;`test2;()!()]
 
-.z.ts:{.kfk.Pub[test_topic;.kfk.PARTITION_UA;string x;""]}
-show "Publishing on topic:",string .kfk.TopicName test_topic;
-.kfk.Pub[test_topic;.kfk.PARTITION_UA;string .z.p;""];
-show "Published 1 message";
+.z.ts:{n+:1;topic:$[n mod 2;topic1;topic2];
+       .kfk.Pub[topic;.kfk.PARTITION_UA;string x;""]}
+
+
+
+-1 "Publishing on topics:",string[.kfk.TopicName topic1],", ",string[.kfk.TopicName topic2];
+.kfk.Pub[;.kfk.PARTITION_UA;string .z.p;""]each(topic1;topic2);
+-1 "Published one message for each topic";
 producer_meta:.kfk.Metadata[producer];
 show producer_meta`topics;
-show "Set timer with \t 1000 to publish message every second";
+-1 "Set timer with \\t 500 to publish a message each second to each topic.";
 


### PR DESCRIPTION
* Addition of support for handling of multiple calls to `.kfk.Sub` to allow for subscriptions to multiple topics for a single client. 
* This functionality has not changed the historical behaviour of any of the functions within the interface.
* Examples have been updated to coincide with the addition of the multiple subscription functionality.