### PR TITLE
Fix to #27 segfault due to undefined group.id

### DIFF
--- a/kfk.q
+++ b/kfk.q
@@ -89,8 +89,8 @@ Producer:Client[PRODUCER;]
 // Consumer client code
 CONSUMER:"c"
 Consumer:{
-  if[not `group.id in key[y];'"Consumers are required to define a `group.id within the config"];
-  .kfk.Client[x;y]}[CONSUMER]
+  if[not `group.id in key y;'"Consumers are required to define a `group.id within the config"];
+  .kfk.Client[x;y]}[CONSUMER;]
 
 // table with kafka statistics
 stats:() 	

--- a/kfk.q
+++ b/kfk.q
@@ -88,7 +88,9 @@ Producer:Client[PRODUCER;]
 
 // Consumer client code
 CONSUMER:"c"
-Consumer:Client[CONSUMER;]
+Consumer:{
+  if[not `group.id in key[y];'"Consumers are required to define a `group.id within the config"];
+  .kfk.Client[x;y]}[CONSUMER]
 
 // table with kafka statistics
 stats:() 	

--- a/kfk.q
+++ b/kfk.q
@@ -92,7 +92,7 @@ Producer:Client[PRODUCER;]
 CONSUMER:"c"
 Consumer:{
   if[not `group.id in key y;'"Consumers are required to define a `group.id within the config"];
-  .kfk.Client[x;y]}[CONSUMER;]
+  Client[x;y]}[CONSUMER;]
 
 // table with kafka statistics
 stats:() 	


### PR DESCRIPTION
* Addition of a check for ``` `group.id ``` within the configuration dictionary, error in absence to prevent segfault
* closes #27  