### PR TITLE
Error/Throttle callback function additions closing #33

### DIFF
--- a/kfk.c
+++ b/kfk.c
@@ -117,23 +117,33 @@ static I printr0(K x){
   return 0;
 }
 
+K decodeMsg(const rd_kafka_t*rk,const rd_kafka_message_t *msg);
+
 static I statscb(rd_kafka_t*UNUSED(rk), S json, size_t json_len, V*UNUSED(opaque)){
   return printr0(k(0, (S) ".kfk.statcb", kpn(json, json_len), KNL));
 } // should return 0 to indicate mem free to kafka
 
-static V logcb(const rd_kafka_t *UNUSED(rk), int level, const char *fac,
-               const char *buf) {
+static V logcb(const rd_kafka_t *UNUSED(rk), int level, const char *fac, const char *buf){
   printr0(k(0, (S) ".kfk.logcb", ki(level), kp((S) fac), kp((S) buf), KNL));
 }
 
-static V offsetcb(rd_kafka_t *rk, rd_kafka_resp_err_t err,rd_kafka_topic_partition_list_t*offsets, V*UNUSED(opaque)){
+static V offsetcb(rd_kafka_t *rk, rd_kafka_resp_err_t err,
+                  rd_kafka_topic_partition_list_t*offsets, V*UNUSED(opaque)){
   printr0(k(0, (S) ".kfk.offsetcb", ki(indexClient(rk)), kp((S)rd_kafka_err2str(err)), decodeParList(offsets),KNL));
 }
 
-K decodeMsg(const rd_kafka_t*rk,const rd_kafka_message_t *msg);
-
 static V drcb(rd_kafka_t*rk,const rd_kafka_message_t *msg,V*UNUSED(opaque)){
   printr0(k(0,(S)".kfk.drcb",ki(indexClient(rk)), decodeMsg(rk,msg),KNL));
+}
+
+static V errorcb(rd_kafka_t *rk, int err, const char *reason, V*UNUSED(opaque)){
+  printr0(k(0, (S) ".kfk.errcb", ki(indexClient(rk)), ki(err), kp((S)reason), KNL));
+}
+
+static V throttlecb(rd_kafka_t *rk, const char *brokername,
+                    int32_t brokerid, int throttle_time_ms, V*UNUSED(opaque)){
+  printr0(k(0,(S) ".kfk.throttlecb", ki(indexClient(rk)),
+          kp((S)brokername), ki(brokerid), ki(throttle_time_ms),KNL));
 }
 
 // client api
@@ -176,6 +186,8 @@ EXP K2(kfkClient){
   rd_kafka_conf_set_log_cb(conf, logcb);
   rd_kafka_conf_set_dr_msg_cb(conf,drcb);
   rd_kafka_conf_set_offset_commit_cb(conf,offsetcb);
+  rd_kafka_conf_set_throttle_cb(conf,throttlecb);
+  rd_kafka_conf_set_error_cb(conf,errorcb);
   if(RD_KAFKA_CONF_OK !=rd_kafka_conf_set(conf, "log.queue", "true", b, sizeof(b)))
     return krr((S) b);
   if(!(rk= rd_kafka_new(type, conf, b, sizeof(b))))

--- a/kfk.q
+++ b/kfk.q
@@ -114,4 +114,17 @@ offsetcb:{[cid;err;offsets]}
 // Main callback for consuming messages(including errors)
 consumecb:{[msg]}
 
+// Addition of error callback (rd_kafka_conf_set_error_cb)
+/* cid is an integer
+/* err_int is an integer code relating to the kafka issue
+/* reason is a string denoting the reason for the error
+errcb:{[cid;err_int;reason]}
+
+// Triggered callback on non-zero throttle time from a broker (rd_kafka_conf_set_throttle_cb)
+/* cid is an integer
+/* broker_name is a string
+/* broker_id is an integer
+/* throttle_time_ms is an integer
+throttlecb:{[cid;broker_name;broker_id;throttle_time_ms]}
+
 \d .


### PR DESCRIPTION
* Addition of error and throttle callbacks in the creation of clients allowing these to be handled by q
* This addition closes #33 
* Example invocation would be to change `.kfk.errcb` function in the `kfk.q` file to 
  ```
  errcb:{[cid;err_int;reason]show (cid;err_int;reason);}
  ```
  - Run the following command from a new q session started with `q kfk.q`
  ```
  q).kfk.Consumer[`metadata.broker.list`group.id!`foobar`0]
  ```
  - This will return the following as expected
  ```
  q)0i
  -193i
  "foobar:9092/bootstrap: Failed to resolve 'foobar:9092': nodename nor servnam..
  0i
  -187i
  "1/1 brokers are down"
  ```