### PR TITLE
Add MaxMsgsPerPoll to prevent thread starvation. Fixes #37

### DIFF
--- a/kfk.c
+++ b/kfk.c
@@ -20,6 +20,7 @@ static SOCKET spair[2];
 #define SOCKET_ERROR -1
 static I spair[2];
 #endif
+static J maxMsgsPerPoll = 0;
 
 #define KR -128
 #define KNL (K) 0
@@ -532,25 +533,35 @@ K decodeMsg(const rd_kafka_t* rk, const rd_kafka_message_t *msg) {
     "msgtime", z, "data", x, "key", y, (S) 0);
 }
 
-J pollClient(rd_kafka_t *rk, J timeout, J UNUSED(maxcnt)) {
+J pollClient(rd_kafka_t *rk, J timeout, J maxcnt) {
+  if(rd_kafka_type(rk) == RD_KAFKA_PRODUCER)
+    return rd_kafka_poll(rk, timeout);
   K r;
   J n= 0;
   rd_kafka_message_t *msg;
-  rd_kafka_type_t rk_type;
-  rk_type= rd_kafka_type(rk);
-  if(rk_type == RD_KAFKA_PRODUCER) {
-    n= rd_kafka_poll(rk, timeout);
-    return n;
-  }
   while((msg= rd_kafka_consumer_poll(rk, timeout))) {
     r= decodeMsg(rk,msg);
     printr0(k(0, ".kfk.consumecb", r, KNL));
     rd_kafka_message_destroy(msg);
-    n++;
+    ++n;
+    /* as n is never 0 in next call, when maxcnt is 0 and maxMsgsPerPoll is 0, doesnt return early */
+    /* maxcnt has priority over maxMsgsPerPoll */
+    if ((maxcnt==n) || (maxMsgsPerPoll==n && maxcnt==0)) 
+    {
+      char data = 'Z';
+      send(spair[1], &data, 1, 0);
+      return n;
+    }
   }
   return n;
 }
 
+EXP K1(kfkMaxMsgsPerPoll){
+  if(!checkType("j", x))
+    return KNL;
+  maxMsgsPerPoll=x->j;
+  return kj(maxMsgsPerPoll);
+}
 
 // for manual poll of the feed.
 EXP K3(kfkPoll){
@@ -619,7 +630,7 @@ EXP K kfkCallback(I d){
     consumed+=n;
   // pass consumed to poll for possible batching
   for(i= 0; i < clients->n; i++)
-    pollClient((rd_kafka_t*)kS(clients)[i], 0, consumed);
+    pollClient((rd_kafka_t*)kS(clients)[i], 0, 0);
   return KNL;
 }
 

--- a/kfk.q
+++ b/kfk.q
@@ -29,6 +29,8 @@ funcs:(
 	(`kfkUnsub;1);
 	  // .kfk.Subscription[client_id:i]
 	(`kfkSubscription;1);
+	  // .kfk.MaxMsgsPerPoll[max_messages]
+	(`kfkMaxMsgsPerPoll;1);
 	  // .kfk.Poll[client_id:i;timeout;max_messages]
 	(`kfkPoll;3);
 	  // .kfk.Version[]:i


### PR DESCRIPTION
.kfk.MaxMsgsPerPoll[max_messages]
Param max_messages (long) max messages to process on a poll.
Default is 0 (process all messages available). Setting a max value will prevent thread starvation on reading a large number of pending messages (e.g. when joining a topic that has a large number of messages stored with `auto.offset.reset;`earliest) or consuming messages slower than the rate of production.

Also fixes existing Poll call where max_messages was ignored.