### PR TITLE
Support for batch publishing. Closes: #29

### DIFF
--- a/kfk.c
+++ b/kfk.c
@@ -395,6 +395,8 @@ EXP K4(kfkPub){
  * @param y Partition to use for all message (int) or partition per message (list of ints)
  * @param z Payload for all messages (mixed list containing either bytes or string).
  * @param r Key. Empty string to use auto key for all messages, or key per message (mixed list containing either bytes or string)
+ * @returns Integer list with a status for each send message (zero indicates success) 
+ *          reference: https://github.com/edenhill/librdkafka/blob/master/src/rdkafka.h (rd_kafka_resp_err_t)
  */
 EXP K4(kfkBatchPub){
   rd_kafka_topic_t *rkt;
@@ -438,8 +440,11 @@ EXP K4(kfkBatchPub){
       rkmessages[i].partition = kI(y)[i]; /* use partition per msg */
   }
   int numOk = rd_kafka_produce_batch(rkt,defaultPartition,msgFlags,rkmessages,msgcnt);
+  K results = ktn(KI, msgcnt);
+  for (i = 0 ; i < msgcnt ; i++)
+    kI(results)[i]=rkmessages[i].err;
   free(rkmessages);
-  return ki(numOk);
+  return results;
 }
 
 // consume api

--- a/kfk.c
+++ b/kfk.c
@@ -398,6 +398,9 @@ EXP K4(kfkPub){
  * @returns Integer list with a status for each send message (zero indicates success) 
  *          reference: https://github.com/edenhill/librdkafka/blob/master/src/rdkafka.h (rd_kafka_resp_err_t)
  */
+
+#if (RD_KAFKA_VERSION >= 0x00080400)
+
 EXP K4(kfkBatchPub){
   rd_kafka_topic_t *rkt;
   if(!checkType("i[iI]*[CG*]", x, y, z, r))
@@ -439,13 +442,21 @@ EXP K4(kfkBatchPub){
     if (y->t == KI)
       rkmessages[i].partition = kI(y)[i]; /* use partition per msg */
   }
-  int numOk = rd_kafka_produce_batch(rkt,defaultPartition,msgFlags,rkmessages,msgcnt);
+  rd_kafka_produce_batch(rkt,defaultPartition,msgFlags,rkmessages,msgcnt);
   K results = ktn(KI, msgcnt);
   for (i = 0 ; i < msgcnt ; i++)
     kI(results)[i]=rkmessages[i].err;
   free(rkmessages);
   return results;
 }
+
+#else
+
+EXP K kfkBatchPub(K UNUSED(x), K UNUSED(y), K UNUSED(z), K UNUSED(r)){
+  return krr("BatchPub unsupported - please update librdkafka");
+}
+
+#endif
 
 // consume api
 EXP K3(kfkSub){

--- a/kfk.c
+++ b/kfk.c
@@ -390,6 +390,58 @@ EXP K4(kfkPub){
   return KNL;
 }
 
+/**
+ * @param x Topic Index (prev created)
+ * @param y Partition to use for all message (int) or partition per message (list of ints)
+ * @param z Payload for all messages (mixed list containing either bytes or string).
+ * @param r Key. Empty string to use auto key for all messages, or key per message (mixed list containing either bytes or string)
+ */
+EXP K4(kfkBatchPub){
+  rd_kafka_topic_t *rkt;
+  if(!checkType("i[iI]*[CG*]", x, y, z, r))
+    return KNL;
+  int msgcnt = z->n;
+  if ((r->t == 0) && (msgcnt != r->n))
+    return krr((S)"msg field not same len as key field");
+  if ((y->t == KI) && (msgcnt != y->n))
+    return krr((S)"msg field not same len as partition field");
+  int i=0;
+  for (i = 0 ; i < msgcnt ; i++)
+  {
+    if (((K*)z->G0)[i]->t != KG && ((K*)z->G0)[i]->t !=KC)
+      return krr((S)"incorrect type for msg");
+    if ((r->t ==0) && ((K*)r->G0)[i]->t != KG && ((K*)r->G0)[i]->t !=KC)
+      return krr((S)"incorrect type for key");
+  }
+  if(!(rkt= topicIndex(x)))
+    return KNL;
+  int defaultPartition = RD_KAFKA_PARTITION_UA;
+  int msgFlags = RD_KAFKA_MSG_F_COPY;
+  if (y->t == KI)
+    msgFlags |= RD_KAFKA_MSG_F_PARTITION; /* use partition per msg */
+  else
+    defaultPartition = y->i; /* partition passed for all msgs */
+  
+  rd_kafka_message_t *rkmessages;
+  rkmessages = calloc(sizeof(*rkmessages), msgcnt);
+  K key = r;
+  for (i = 0 ; i < msgcnt ; i++)
+  {
+    K msg = ((K*)z->G0)[i];
+    if (r->t == 0)
+      key = ((K*)r->G0)[i];
+    rkmessages[i].payload = kG(msg);
+    rkmessages[i].len = msg->n;
+    rkmessages[i].key = kG(key);
+    rkmessages[i].key_len = key->n;
+    if (y->t == KI)
+      rkmessages[i].partition = kI(y)[i]; /* use partition per msg */
+  }
+  int numOk = rd_kafka_produce_batch(rkt,defaultPartition,msgFlags,rkmessages,msgcnt);
+  free(rkmessages);
+  return ki(numOk);
+}
+
 // consume api
 EXP K3(kfkSub){
   rd_kafka_resp_err_t err;

--- a/kfk.c
+++ b/kfk.c
@@ -399,7 +399,7 @@ EXP K4(kfkPub){
  *          reference: https://github.com/edenhill/librdkafka/blob/master/src/rdkafka.h (rd_kafka_resp_err_t)
  */
 
-#if (RD_KAFKA_VERSION >= 0x00080400)
+#if (RD_KAFKA_VERSION >= 0x000b04ff)
 
 EXP K4(kfkBatchPub){
   rd_kafka_topic_t *rkt;

--- a/kfk.q
+++ b/kfk.q
@@ -21,6 +21,8 @@ funcs:(
 	(`kfkMetadata;1);
 	  // .kfk.Pub[topic_id:i;partid:i;data;key]:_
 	(`kfkPub;4);
+	  // .kfk.BatchPub[topic_id:i;partid:i;data;key]:_
+	(`kfkBatchPub;4);
 	  // .kfk.OutQLen[client_id:i]:i
 	(`kfkOutQLen;1);
 	  // .kfk.Sub[client_id:i;topicname:s;partition_list|partition_offsets:I!J]:()


### PR DESCRIPTION
Support for batch publish.

Example use:
```
/ send 2 msgs to any partition for topic, use default key generation
 .kfk.BatchPub[;.kfk.PARTITION_UA;batchMsg;""]each(topic1;topic2);
/ send 2 msgs to partition 1 for topic, use default key generation
 .kfk.BatchPub[;1i;batchMsg;""]each(topic1;topic2);
/ send 2 msgs. First to partition 0 and second to partition 1. Use keys provided for each msg.
.kfk.BatchPub[;(0i;1i);batchMsg;batchKeys]each(topic1;topic2);
```

```
* @param x Topic Index (prev created)
 * @param y Partition to use for all message (int) or partition per message (list of ints)
 * @param z Payload for all messages (mixed list containing either bytes or string).
 * @param r Key. Empty string to use auto key for all messages, or key per message (mixed list containing either bytes or string)
 * @returns Integer list with a status for each send message (zero indicates success) 
 *          reference: https://github.com/edenhill/librdkafka/blob/master/src/rdkafka.h (rd_kafka_resp_err_t)

```
Requires librdkafka be release 0.11.4 and above.
If older, function still exists but returns an error saying its unsupported.