### PR TITLE
Logic for handling of per topic callbacks, updated examples

### DIFF
--- a/examples/test_consumer.q
+++ b/examples/test_consumer.q
@@ -9,17 +9,26 @@ kfk_cfg:(!) . flip(
     );
 client:.kfk.Consumer[kfk_cfg];
 
-data:();
-.kfk.consumecb:{[msg]
-    msg[`data]:"c"$msg[`data];
-    msg[`rcvtime]:.z.p;
-    data,::enlist msg;}
-
 // Topics to subscribe to
 topic1:`test1; topic2:`test2;
 
-// Subscribe to multiple topics from a single client
-.kfk.Sub[client;;enlist .kfk.PARTITION_UA]each(topic1;topic2);
+// Define datasets and topic callbacks for individual
+// topic subscriptions `topic1 and `topic2
+data1:();
+topcb1:{[msg]
+  msg[`data]:"c"$msg[`data];
+  msg[`rcvtime]:.z.p;
+  data1,::enlist msg;}
+
+data2:();
+topcb2:{[msg]
+  msg[`data]:"c"$msg[`data];
+  msg[`rcvtime]:.z.t;
+  data2,::enlist msg;}
+
+// Subscribe to topic1 and topic2 with different callbacks from a single client
+.kfk.Subscribe[client;topic1;enlist .kfk.PARTITION_UA;topcb1]
+.kfk.Subscribe[client;topic2;enlist .kfk.PARTITION_UA;topcb2]
 
 client_meta:.kfk.Metadata[client];
 show client_meta`topics;

--- a/examples/test_offsetc.q
+++ b/examples/test_offsetc.q
@@ -16,8 +16,8 @@ topic1:`test1
 topic2:`test2
 data:();
 
-// Callback function for managing of messages
-.kfk.consumecb:{[msg]
+// Default callback function overwritten for managing of consumption from all topics
+.kfk.consumetopic[`]:{[msg]
     msg[`data]:"c"$msg[`data];
     msg[`rcvtime]:.z.p;
     data,::enlist msg;}
@@ -26,6 +26,7 @@ data:();
 
 // Assign partitions to consume from specified offsets
 show .kfk.AssignOffsets[client;;(1#0i)!1#.kfk.OFFSET.END]each (topic1;topic2)
+
 // Subscribe to relevant topics from a defined client
 .kfk.Sub[client;;(1#0i)!1#.kfk.OFFSET.END]each (topic1;topic2)
 

--- a/kfk.q
+++ b/kfk.q
@@ -115,8 +115,22 @@ drcb:{[cid;msg]}
 // CONSUMER: offset commit callback(rd_kafka_conf_set_offset_commit_cb)
 offsetcb:{[cid;err;offsets]}
 
-// Main callback for consuming messages(including errors)
-consumecb:{[msg]}
+// Default callback for consuming messages if individual topic callbacks not defined(including errors)
+consumetopic.:{[msg]}
+
+// Main function called on consumption of data for both default and per topic callback
+consumecb:{[msg]$[null f:consumetopic msg`topic;consumetopic.;f]msg}
+
+// Subscribe to a topic from a client, with a defined topic/partition offset and unique callback function
+/* cid  = Integer denoting client Id
+/* top  = Topic to be subscribed to as a symbol
+/* part = Partition list or partition/offset dictionary
+/* cb   = callback function to be used for the specified topic
+Subscribe:{[cid;top;part;cb]
+  Sub[cid;top;part];
+  if[not null cb;consumetopic[top]:cb];
+  }
+
 
 // Addition of error callback (rd_kafka_conf_set_error_cb)
 /* cid is an integer


### PR DESCRIPTION
This PR addresses and closes #31 

* Addition of the function `.kfk.Subscribe` which is a wrapped function around `.kfk.Sub`, this function:
  1. Takes the same 3 initial arguments as `.kfk.Sub` the 4th argument is the callback function which should be called for the topic being subscribed to
  2. The function augments the dictionary `.kfk.consumetopic` with a key for the name of the topic .i.e ```.kfk.consumetopic[`topicname]:{[msg]show msg;}```
  3. The default general behaviour previously defined in `.kfk.consumecb` now wrapped in ```.kfk.consumetopic[`] ```) 
* Examples updated in line with the above changes, `test_consumer.q` handles both `topic1` and `topic2` separately (timestamp vs time rcvtime is the difference between the tables). `test_offsetc.q` overwrites the default behaviour for both topics rather than treating them differently as an example.