### PR TITLE
Assignment functionality addition

### DIFF
--- a/kfk.c
+++ b/kfk.c
@@ -678,11 +678,11 @@ static V ptlistdel(K dict,rd_kafka_topic_partition_list_t *t_partition){
  * @returns Null value on correct execution
 */
 
-EXP K2(kfkAssign){
+EXP K2(kfkAssignTopPar){
   rd_kafka_t *rk;
   rd_kafka_topic_partition_list_t *t_partition;
   rd_kafka_resp_err_t err;
-  if(!checkType("i!", x, y))
+  if(!checkType("i", x))
     return KNL;
   if(!(rk= clientIndex(x)))
     return KNL;

--- a/kfk.c
+++ b/kfk.c
@@ -644,6 +644,126 @@ EXP K3(kfkPoll){
   return kj(n);
 }
 
+
+/* The following set of functions define interactions with the assign functionality with Kafka.
+ * This provides more control to the user over where data can be consumed from.
+ * Note the differences between Kafka Assign vs Subscribe functionality, summarised in part
+ * https://github.com/confluentinc/confluent-kafka-dotnet/issues/278#issuecomment-318858243
+*/
+
+/** Define functionality needed for the addition and deletion of topic-partition 
+ ** pairs to the current assignment
+ * @param dict topic!associated-partitions --> S!J
+*/
+
+static V ptlistadd(K dict, rd_kafka_topic_partition_list_t *t_partition){
+  K dk=kK(dict)[0],dv=kK(dict)[1];
+  S*p;J*o,i;
+  p=kS(dk);o=kJ(dv);
+  for(i = 0; i < dk->n; i++)
+    rd_kafka_topic_partition_list_add(t_partition,p[i],o[i]);
+}
+
+static V ptlistdel(K dict,rd_kafka_topic_partition_list_t *t_partition){
+  K dk=kK(dict)[0],dv=kK(dict)[1];
+  S*p;J*o,i;
+  p=kS(dk);o=kJ(dv);
+  for(i = 0; i < dk->n; i++)
+    rd_kafka_topic_partition_list_del(t_partition,p[i],o[i]);
+}
+
+/** Assign the partitions from which to consume data for specified topics
+ * @param x Client Index (previously created)
+ * @param y Dictionary mapping individual topics to associated partitions. S!J
+ * @returns Null value on correct execution
+*/
+
+EXP K2(kfkAssign){
+  rd_kafka_t *rk;
+  rd_kafka_topic_partition_list_t *t_partition;
+  rd_kafka_resp_err_t err;
+  if(!checkType("i!", x, y))
+    return KNL;
+  if(!(rk= clientIndex(x)))
+    return KNL;
+  t_partition = rd_kafka_topic_partition_list_new(y->n);
+  // topic-partition assignment
+  ptlistadd(y,t_partition);
+  if(KFK_OK != (err=rd_kafka_assign(rk,t_partition)))
+    return krr((S) rd_kafka_err2str(err));
+  rd_kafka_topic_partition_list_destroy(t_partition);
+  return KNL;
+}
+
+/** Return the current consumption assignment for a specified client
+ * @param x Client Index (previously created) 
+ * @returns List of dictionaries defining information about the current assignment
+*/
+EXP K1(kfkAssignment){
+  K r;
+  rd_kafka_topic_partition_list_t *t;
+  rd_kafka_t *rk;
+  rd_kafka_resp_err_t err;
+  if(!checkType("i", x))
+    return KNL;
+  if(!(rk= clientIndex(x)))
+    return KNL;
+  if(KFK_OK != (err=rd_kafka_assignment(rk, &t)))
+    return krr((S)rd_kafka_err2str(err));
+  r = decodeParList(t);
+  rd_kafka_topic_partition_list_destroy(t);
+  return r;
+}
+
+/** Add to the current assignment for a client with new topic-partition pair
+ * @param x Client Index (previously created)
+ * @param y Dictionary mapping individual topics to associated partitions. S!J
+ * @returns Null value on correct execution
+*/
+
+EXP K2(kfkAssignmentAdd){
+  rd_kafka_t *rk;
+  rd_kafka_topic_partition_list_t *t;
+  rd_kafka_resp_err_t err;
+  if(!checkType("i", x))
+    return KNL;
+  if(!(rk= clientIndex(x)))
+    return KNL;
+  // retrieve the current assignment
+  if(KFK_OK != (err=rd_kafka_assignment(rk, &t)))
+    return krr((S)rd_kafka_err2str(err));
+  ptlistadd(y,t);
+  if(KFK_OK != (err=rd_kafka_assign(rk,t)))
+    return krr((S) rd_kafka_err2str(err));
+  rd_kafka_topic_partition_list_destroy(t);
+  return 0;
+}
+
+/** Delete a topic-partition mapped dictionary from the current assignment for a client
+ * @param x Client Index (previously created)
+ * @param y Dictionary mapping individual topics to associated partitions. S!J
+ * @returns Null value on correct execution
+*/
+
+EXP K2(kfkAssignmentDel){
+  rd_kafka_t *rk;
+  rd_kafka_topic_partition_list_t *t;
+  rd_kafka_resp_err_t err;
+  if(!checkType("i", x))
+    return KNL;
+  if(!(rk= clientIndex(x)))
+    return KNL;
+  // retrieve the current assignment
+  if(KFK_OK != (err=rd_kafka_assignment(rk, &t)))
+    return krr((S)rd_kafka_err2str(err));
+  ptlistdel(y,t);
+  if(KFK_OK != (err=rd_kafka_assign(rk,t)))
+    return krr((S) rd_kafka_err2str(err));
+  rd_kafka_topic_partition_list_destroy(t);
+  return 0;
+}
+
+
 // other
 EXP K1(kfkOutQLen){
   rd_kafka_t *rk;

--- a/kfk.q
+++ b/kfk.q
@@ -21,6 +21,8 @@ funcs:(
 	(`kfkMetadata;1);
 	  // .kfk.Pub[topic_id:i;partid:i;data;key]:_
 	(`kfkPub;4);
+	  // .kfk.BatchPub[topic_id:i;partid:i;data;key]:_
+	(`kfkBatchPub;4);
 	  // .kfk.OutQLen[client_id:i]:i
 	(`kfkOutQLen;1);
 	  // .kfk.Sub[client_id:i;topicname:s;partition_list|partition_offsets:I!J]:()

--- a/kfk.q
+++ b/kfk.q
@@ -54,7 +54,15 @@ funcs:(
           // .kfk.VersionSym[]:s
         (`kfkVersionSym;1);
           // .kfk.SetLoggerLevel[client_id:i;int_level:i]:()
-        (`kfkSetLoggerLevel;2)
+        (`kfkSetLoggerLevel;2);
+          // .kfk.Assignment[client_id:i]:T
+        (`kfkAssignment;1);
+          // .kfk.Assign[client_id:i;topic_partition:S!J]:()
+        (`kfkAssign;2);
+          // .kfk.AssignmentAdd[client_id:i;topic_partition:S!J]:()
+        (`kfkAssignmentAdd;2);
+          // .kfk.AssignmentDel[client_id:i;topic_partition:S!J]:()
+        (`kfkAssignDel;2);
 	);
 
 // binding functions from dictionary funcs using rule


### PR DESCRIPTION
As alluded to in #28 the interface to this point did not facilitate the use of the assignment functionality.

This functionality is similar in nature to subscriptions in so far as it allows for control to be given to a user surrounding what data is consumed. For more detailed differences between subscriptions and assignments the following discussion is useful [here](https://github.com/confluentinc/confluent-kafka-dotnet/issues/278#issuecomment-318858243)

Changes in this PR are as follows

Addition:
* `.kfk.Assignment[cid]` - return the current assignment for a client defined by client id `cid`
* `.kfk.Assign[cid;toppar]` - Assign the dictionary `toppar` mapping `S!J` to the client id `cid`
* `.kfk.AssignAdd[cid;toppar]` - Add the `toppar` mapping `S!J` to the current assignment for client id `cid`
* `.kfk.AssignDel[cid;toppar]` - Delete the `toppar` mapping `S!J` from the current assignment for client id `cid`