### PR TITLE
Update to error and throttle callback logic

### DIFF
--- a/kfk.q
+++ b/kfk.q
@@ -134,17 +134,33 @@ Subscribe:{[cid;top;part;cb]
   }
 
 
-// Addition of error callback (rd_kafka_conf_set_error_cb)
+// Handling of error callbacks (rd_kafka_conf_set_error_cb)
 /* cid is an integer
 /* err_int is an integer code relating to the kafka issue
 /* reason is a string denoting the reason for the error
-errcb:{[cid;err_int;reason]}
 
-// Triggered callback on non-zero throttle time from a broker (rd_kafka_conf_set_throttle_cb)
-/* cid is an integer
-/* broker_name is a string
-/* broker_id is an integer
-/* throttle_time_ms is an integer
-throttlecb:{[cid;broker_name;broker_id;throttle_time_ms]}
+// Default callback for the handling of errors 
+errclient.:{[cid;err_int;reason]}
+// Main function for the handling of error callbacks
+errcb:{[cid;err_int;reason]$[null f:errclient`$string cid;errclient.;f].(cid;err_int;reason)}
+// Registration function allowing error callbacks to be added on a per client basis
+errcbreg:{[cid;cb]if[not null cb;errclient[`$string cid]:cb];}
+
+
+// Handling of throttle callbacks (rd_kafka_conf_set_throttle_cb)
+/* cid is an integer denoting the client id from which the callback is triggered
+/* bname is a string denoting the name of the broker
+/* bid is an integer denoting the broker id
+/* throttle_time is an integer denoting the non-zero throttle time that triggered the callback
+
+// Default callback for the handling of throttle events
+throttleclient.:{[cid;bname;bid;throttle_time]}
+// Main function for the handling of throttle events
+throttlecb:{[cid;bname;bid;throttle_time]
+  $[null f:throttleclient`$string cid;throttleclient.;f].(cid;bname;bid;throttle_time)
+  }
+// Registration function allowing throttle callbacks to be set of a per client basis
+throttlecbreg:{[cid;cb]if[not null cb;throttleclient[`$string cid]:cb];}
+
 
 \d .


### PR DESCRIPTION
This issue closes #53 and expands on the functionality to include a similar granularity to throttle callback

This updated functionality allows individual callbacks to be set on a per client basis for both the error and throttle callbacks while continuing to provide a default behaviour.

The following example shows this functionality for the error callback functionality, the throttle callback functionality follows the same pattern

```
// Default behaviour (do nothing)
q).kfk.errclient
| {[cid;err_int;reason]}
// Attempt to create a consumer which will fail
q).kfk.Consumer[`metadata.broker.list`group.id!`foobar`0]
0i
// Update the default behaviour to show the output
q).kfk.errclient[`]:{[cid;err_int;reason]show(cid;err_int;reason);}
// Attempt to create another failing consumer
q).kfk.Consumer[`metadata.broker.list`group.id!`foobar`0]
1i
q)1i
-193i
"foobar:9092/bootstrap: Failed to resolve 'foobar:9092': nodename nor servnam..
1i
-187i
"1/1 brokers are down"

// Start a new q session and register an error callback for cid 0
q).kfk.errcbreg[0i;{[cid;err_int;reason] show err_int;}]
// Attempt to create a consumer that will fail
q).kfk.Consumer[`metadata.broker.list`group.id!`foobar`0]
0i
q)-193i
-187i
```