### PR TITLE
Fix for calls to non existing clients, closes #61

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,13 @@
 OSFLAG :=
 MS :=
 
-ifeq ($(KAFKA_ROOT)),)
-        KFK_ROOT="${HOME}"
-else
-        KFK_ROOT="${KAFKA_ROOT}"
-endif
+KFK_ROOT=${HOME}
 KFK_INCLUDE    = ${KFK_ROOT}/include
 W_OPTS         = -Wall -Wno-strict-aliasing -Wno-parentheses -Wextra -Werror -Wsign-compare
 OPTS           = -DKXVER=3 -shared -fPIC $(W_OPTS)
 LD_COMMON      = -lz -lpthread -lssl -g -O2
-LDOPTS_DYNAMIC = -L${KAFKA_ROOT}/lib/ -lrdkafka
-LDOPTS_STATIC  = ${KAFKA_ROOT}/lib/librdkafka.a
+LDOPTS_DYNAMIC = -L${KFK_ROOT}/lib/ -lrdkafka
+LDOPTS_STATIC  = ${KFK_ROOT}/lib/librdkafka.a
 MS             = $(shell getconf LONG_BIT)
 TGT            = libkfk.so
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 OSFLAG :=
 MS :=
 
-KFK_ROOT=${HOME}
+ifeq ($(KAFKA_ROOT)),)
+        KFK_ROOT="${HOME}"
+else
+        KFK_ROOT="${KAFKA_ROOT}"
+endif
 KFK_INCLUDE    = ${KFK_ROOT}/include
 W_OPTS         = -Wall -Wno-strict-aliasing -Wno-parentheses -Wextra -Werror -Wsign-compare
 OPTS           = -DKXVER=3 -shared -fPIC $(W_OPTS)

--- a/kfk.c
+++ b/kfk.c
@@ -96,7 +96,6 @@ rd_kafka_t *clientIndex(K x){
   return (rd_kafka_t *) ((((UI) xi < clients->n) && kS(clients)[xi]) ?kS(clients)[xi] :(S) krr("unknown client"));
 }
 
-
 I indexClient(const rd_kafka_t *rk){
   int i;
   for (i = 0; i < clients->n; ++i)
@@ -711,10 +710,12 @@ static V detach(V){
     r0(topics);
   }
   if(clients){
-    for(i= 0; i < clients->n; i++)
-      kfkClientDel(ki(i));
-    rd_kafka_wait_destroyed(1000); /* wait for cleanup*/
-    r0(clients);
+    for(i= 0; i < clients->n; i++){
+      if(!((S)0 == kS(clients)[i]))   /* ignore any clients that have been deleted previously */
+        kfkClientDel(ki(i));
+    }
+    rd_kafka_wait_destroyed(1000);    /* wait for cleanup*/
+    r0(clients); 
   }
   if(sp=spair[0]){
     sd0x(sp,0);

--- a/kfk.c
+++ b/kfk.c
@@ -96,6 +96,7 @@ rd_kafka_t *clientIndex(K x){
   return (rd_kafka_t *) ((((UI) xi < clients->n) && kS(clients)[xi]) ?kS(clients)[xi] :(S) krr("unknown client"));
 }
 
+
 I indexClient(const rd_kafka_t *rk){
   int i;
   for (i = 0; i < clients->n; ++i)
@@ -697,8 +698,10 @@ EXP K kfkCallback(I d){
   while(0 < (n=recv(d, buf, sizeof(buf), 0)))
     consumed+=n;
   // pass consumed to poll for possible batching
-  for(i= 0; i < clients->n; i++)
-    pollClient((rd_kafka_t*)kS(clients)[i], 0, 0);
+  for(i= 0; i < clients->n; i++){
+    if(!(((S)0)==kS(clients)[i]))
+      pollClient((rd_kafka_t*)kS(clients)[i], 0, 0);
+  }
   return KNL;
 }
 
@@ -711,11 +714,11 @@ static V detach(V){
   }
   if(clients){
     for(i= 0; i < clients->n; i++){
-      if(!((S)0 == kS(clients)[i]))   /* ignore any clients that have been deleted previously */
+      if(!(((S)0) == kS(clients)[i]))
         kfkClientDel(ki(i));
     }
-    rd_kafka_wait_destroyed(1000);    /* wait for cleanup*/
-    r0(clients); 
+    rd_kafka_wait_destroyed(1000); /* wait for cleanup*/
+    r0(clients);
   }
   if(sp=spair[0]){
     sd0x(sp,0);


### PR DESCRIPTION
* This fix closes #61 
* Issue is that interface had been attempting to invoke callbacks on clients that had been deleted.
* In addition to this, calls to the detach functionality which are invoked atexit were causing q to error due to the clients that were no longer being available to disconnect. This is now handled and checked by comparison with `(S)0`
* Naming convention for KAFKA_ROOT was not consistent in the makefile, modified to use the naming convention within the if/else statement at the top of the file