### PR TITLE
Logic to handle consumer/producer only callbacks. Closes #63

### DIFF
--- a/examples/test_consumer.q
+++ b/examples/test_consumer.q
@@ -3,7 +3,6 @@
 kfk_cfg:(!) . flip(
     (`metadata.broker.list;`localhost:9092);
     (`group.id;`0);
-    (`queue.buffering.max.ms;`1);
     (`fetch.wait.max.ms;`10);
     (`statistics.interval.ms;`10000)
     );

--- a/kfk.c
+++ b/kfk.c
@@ -186,8 +186,10 @@ EXP K2(kfkClient){
     return KNL;
   rd_kafka_conf_set_stats_cb(conf, statscb);
   rd_kafka_conf_set_log_cb(conf, logcb);
-  rd_kafka_conf_set_dr_msg_cb(conf,drcb);
-  rd_kafka_conf_set_offset_commit_cb(conf,offsetcb);
+  if('p' == xg)
+    rd_kafka_conf_set_dr_msg_cb(conf,drcb);
+  else
+    rd_kafka_conf_set_offset_commit_cb(conf,offsetcb);
   rd_kafka_conf_set_throttle_cb(conf,throttlecb);
   rd_kafka_conf_set_error_cb(conf,errorcb);
   if(RD_KAFKA_CONF_OK !=rd_kafka_conf_set(conf, "log.queue", "true", b, sizeof(b)))


### PR DESCRIPTION
* Prior to the addition of error callback logic, invalid callback setting was not caught. As highlighted by #63 both `dr_msg_cb` and `set_offset_cb` are specific to producers and consumers only.
* The addition of error callback also showed that the `queue.buffering.max.ms` config was not valid for consumers
* This closes #63 