### PR TITLE
Topic deletion on client delete

### DIFF
--- a/examples/test_consumer.q
+++ b/examples/test_consumer.q
@@ -3,7 +3,6 @@
 kfk_cfg:(!) . flip(
     (`metadata.broker.list;`localhost:9092);
     (`group.id;`0);
-    (`queue.buffering.max.ms;`1);
     (`fetch.wait.max.ms;`10);
     (`statistics.interval.ms;`10000)
     );

--- a/kfk.c
+++ b/kfk.c
@@ -787,8 +787,10 @@ EXP K kfkCallback(I d){
 static V detach(V){
   I sp,i;
   if(topics){
-    for(i= 0; i < topics->n; i++)
-      kfkTopicDel(ki(i));
+    for(i= 0; i < topics->n; i++){
+      if(!(((S)0) == kS(clients)[i]))
+        kfkTopicDel(ki(i));
+    }
     r0(topics);
   }
   if(clients){

--- a/kfk.c
+++ b/kfk.c
@@ -186,8 +186,10 @@ EXP K2(kfkClient){
     return KNL;
   rd_kafka_conf_set_stats_cb(conf, statscb);
   rd_kafka_conf_set_log_cb(conf, logcb);
-  rd_kafka_conf_set_dr_msg_cb(conf,drcb);
-  rd_kafka_conf_set_offset_commit_cb(conf,offsetcb);
+  if('p' == xg)
+    rd_kafka_conf_set_dr_msg_cb(conf,drcb);
+  else
+    rd_kafka_conf_set_offset_commit_cb(conf,offsetcb);
   rd_kafka_conf_set_throttle_cb(conf,throttlecb);
   rd_kafka_conf_set_error_cb(conf,errorcb);
   if(RD_KAFKA_CONF_OK !=rd_kafka_conf_set(conf, "log.queue", "true", b, sizeof(b)))

--- a/kfk.c
+++ b/kfk.c
@@ -209,7 +209,7 @@ EXP K2(kfkClient){
   return ki(clients->n - 1);
 }
 
-EXP K1(kfkClientDel){
+EXP K1(kfkdeleteClient){
   rd_kafka_t *rk;
   if(!checkType("i", x))
     return KNL;
@@ -240,7 +240,7 @@ EXP K1(kfkClientMemberId){
 }
 
 // topic api
-EXP K3(kfkTopic){
+EXP K3(kfkgenerateTopic){
   rd_kafka_topic_t *rkt;
   rd_kafka_t *rk;
   rd_kafka_topic_conf_t *rd_topic_conf;
@@ -787,16 +787,15 @@ EXP K kfkCallback(I d){
 static V detach(V){
   I sp,i;
   if(topics){
-    for(i= 0; i < topics->n; i++){
-      if(!(((S)0) == kS(clients)[i]))
+    for(i= 0; i < topics->n; i++)
+      if(!(((S)0) == kS(topics)[i]))
         kfkTopicDel(ki(i));
-    }
     r0(topics);
   }
   if(clients){
     for(i= 0; i < clients->n; i++){
       if(!(((S)0) == kS(clients)[i]))
-        kfkClientDel(ki(i));
+        kfkdeleteClient(ki(i));
     }
     rd_kafka_wait_destroyed(1000); /* wait for cleanup*/
     r0(clients);

--- a/kfk.q
+++ b/kfk.q
@@ -5,7 +5,7 @@ funcs:(
 	(`kfkInit;1);
 	  // .kfk.Client[client_type:c;conf:S!S]:i
 	(`kfkClient;2);
-	  // .kfk.ClientDel[client_id:i]:_
+	  // .kfk.deleteClient[client_id:i]:_
 	(`kfkdeleteClient;1);
 	  // .kfk.ClientName[client_id:i]:s
 	(`kfkClientName;1);

--- a/kfk.q
+++ b/kfk.q
@@ -89,13 +89,13 @@ OFFSET.STORED:	 -1000  /**< Start consuming from offset retrieved from offset st
 OFFSET.INVALID:	 -1001  /**< Invalid offset */
 
 // Placeholder to allow mapping between 
-ClientTopicMap:()!()
+ClientTopicMap:(`int$())!()
 
 // Producer client code
 PRODUCER:"p"
 Producer:{
   client:Client[x;y];
-  .kfk.ClientTopicMap,::enlist[client]!enlist ();
+  .kfk.ClientTopicMap,:enlist[client]!enlist ();
   client}[PRODUCER]
 
 // Consumer client code
@@ -103,20 +103,20 @@ CONSUMER:"c"
 Consumer:{
   if[not `group.id in key y;'"Consumers are required to define a `group.id within the config"];
   client:Client[x;y];
-  .kfk.ClientTopicMap,::enlist[client]!enlist ();
+  .kfk.ClientTopicMap,:enlist[client]!enlist ();
   client}[CONSUMER]
 
 // Addition of topics and mapping
 Topic:{[cid;tname;conf]
   topic:generateTopic[cid;tname;conf];
-  .kfk.ClientTopicMap[cid],::topic;
+  .kfk.ClientTopicMap[cid],:topic;
   topic
   }
 
-ClientDel:{[clientMap;cid]
-  @[TopicDel;;()]each .kfk.ClientTopicMap[cid];
+ClientDel:{[cid]
+  @[TopicDel;;()]each ClientTopicMap[cid];
   deleteClient[cid]
-  }[ClientTopicMap]
+  }
 
 // table with kafka statistics
 stats:() 	

--- a/kfk.q
+++ b/kfk.q
@@ -88,7 +88,7 @@ OFFSET.END:     		-1  /**< Start consuming from end of kafka partition queue: ne
 OFFSET.STORED:	 -1000  /**< Start consuming from offset retrieved from offset store */
 OFFSET.INVALID:	 -1001  /**< Invalid offset */
 
-// Placeholder to allow mapping between 
+// Placeholder to allow mapping between client and associated topics
 ClientTopicMap:(`int$())!()
 
 // Producer client code

--- a/kfk.q
+++ b/kfk.q
@@ -6,13 +6,13 @@ funcs:(
 	  // .kfk.Client[client_type:c;conf:S!S]:i
 	(`kfkClient;2);
 	  // .kfk.ClientDel[client_id:i]:_
-	(`kfkClientDel;1);
+	(`kfkdeleteClient;1);
 	  // .kfk.ClientName[client_id:i]:s
 	(`kfkClientName;1);
 	  // .kfk.ClientMemberId[client_id:i]:s
 	(`kfkClientMemberId;1);
-	  // .kfk.Topic[client_id:i;topicname:s;conf:S!S]:i
-	(`kfkTopic;3);
+	  // .kfk.generateTopic[client_id:i;topicname:s;conf:S!S]:i
+	(`kfkgenerateTopic;3);
 	  // .kfk.TopicDel[topic_id:i]:_
 	(`kfkTopicDel;1);
 	  // .kfk.TopicName[topic_id:i]:s
@@ -88,15 +88,35 @@ OFFSET.END:     		-1  /**< Start consuming from end of kafka partition queue: ne
 OFFSET.STORED:	 -1000  /**< Start consuming from offset retrieved from offset store */
 OFFSET.INVALID:	 -1001  /**< Invalid offset */
 
+// Placeholder to allow mapping between 
+ClientTopicMap:()!()
+
 // Producer client code
 PRODUCER:"p"
-Producer:Client[PRODUCER;]
+Producer:{
+  client:Client[x;y];
+  .kfk.ClientTopicMap,::enlist[client]!enlist ();
+  client}[PRODUCER]
 
 // Consumer client code
 CONSUMER:"c"
 Consumer:{
   if[not `group.id in key y;'"Consumers are required to define a `group.id within the config"];
-  Client[x;y]}[CONSUMER;]
+  client:Client[x;y];
+  .kfk.ClientTopicMap,::enlist[client]!enlist ();
+  client}[CONSUMER]
+
+// Addition of topics and mapping
+Topic:{[cid;tname;conf]
+  topic:generateTopic[cid;tname;conf];
+  .kfk.ClientTopicMap[cid],::topic;
+  topic
+  }
+
+ClientDel:{[clientMap;cid]
+  @[TopicDel;;()]each .kfk.ClientTopicMap[cid];
+  deleteClient[cid]
+  }[ClientTopicMap]
 
 // table with kafka statistics
 stats:() 	


### PR DESCRIPTION
This PR deals with the following issues
* close #65 
* closes #57 

Previously deleting a client would not result in topics connected to that client being deleted, this had implications when attempting to publish to a topic that had been deleted and when cleaning up the process at detach.