### PR TITLE
Fix for issue #68 (.kfk.ClientMemberId causes segfault when called with producer handles)

### DIFF
--- a/kfk.c
+++ b/kfk.c
@@ -230,7 +230,7 @@ EXP K1(kfkClientName){
   return ks((S) rd_kafka_name(rk));
 }
 
-EXP K1(kfkClientMemberId){
+EXP K1(kfkmemberID){
   rd_kafka_t *rk;
   if(!checkType("i", x))
     return KNL;

--- a/kfk.q
+++ b/kfk.q
@@ -9,8 +9,8 @@ funcs:(
 	(`kfkdeleteClient;1);
 	  // .kfk.ClientName[client_id:i]:s
 	(`kfkClientName;1);
-	  // .kfk.ClientMemberId[client_id:i]:s
-	(`kfkClientMemberId;1);
+	  // .kfk.memberId[client_id:i]:s
+	(`kfkmemberID;1);
 	  // .kfk.generateTopic[client_id:i;topicname:s;conf:S!S]:i
 	(`kfkgenerateTopic;3);
 	  // .kfk.TopicDel[topic_id:i]:_
@@ -96,14 +96,17 @@ OFFSET.END:     		-1  /**< Start consuming from end of kafka partition queue: ne
 OFFSET.STORED:	 -1000  /**< Start consuming from offset retrieved from offset store */
 OFFSET.INVALID:	 -1001  /**< Invalid offset */
 
-// Placeholder to allow mapping between client and associated topics
+// Mapping between client and the topics associated with these clients
 ClientTopicMap:(`int$())!()
+// Mapping between client and the type of handle created i.e. producer/consumer
+ClientTypeMap :(`int$())!`symbol$()
 
 // Producer client code
 PRODUCER:"p"
 Producer:{
   client:Client[x;y];
   .kfk.ClientTopicMap,:enlist[client]!enlist ();
+  .kfk.ClientTypeMap ,:enlist[client]!enlist[`Producer];
   client}[PRODUCER]
 
 // Consumer client code
@@ -112,6 +115,7 @@ Consumer:{
   if[not `group.id in key y;'"Consumers are required to define a `group.id within the config"];
   client:Client[x;y];
   .kfk.ClientTopicMap,:enlist[client]!enlist ();
+  .kfk.ClientTypeMap ,:enlist[client]!enlist[`Consumer];
   client}[CONSUMER]
 
 // Addition of topics and mapping
@@ -134,9 +138,13 @@ stats:()
 
 // statistics provided by kafka about current state (rd_kafka_conf_set_stats_cb)
 statcb:{[j]
-	s:.j.k j;if[all `ts`time in key s;s[`ts]:-10957D+`timestamp$s[`ts]*1000;s[`time]:-10957D+`timestamp$1000000000*s[`time]];
-	.kfk.stats,::enlist s;
-	delete from `.kfk.stats where i<count[.kfk.stats]-100;}
+  s:.j.k j;
+  if[all `ts`time in key s;
+    s[`ts]:-10957D+`timestamp$s[`ts]*1000;
+    s[`time]:-10957D+`timestamp$1000000000*s[`time]
+    ];
+  .kfk.stats,::enlist s;
+  delete from `.kfk.stats where i<count[.kfk.stats]-100;}
 
 // logger callback(rd_kafka_conf_set_log_cb)
 logcb:{[level;fac;buf] show -3!(level;fac;buf);}
@@ -161,6 +169,14 @@ consumecb:{[msg]$[null f:consumetopic msg`topic;consumetopic.;f]msg}
 Subscribe:{[cid;top;part;cb]
   Sub[cid;top;part];
   if[not null cb;consumetopic[top]:cb];
+  }
+
+
+// Retrieve the client member id associated with an assigned consumer
+/* cid    = Integer denoting client ID
+ClientMemberId:{[cid]
+  if[`Producer~ClientTypeMap[cid];'".kfk.ClientMemberID cannot be called on Producer clients"];
+  memberID[cid]
   }
 
 


### PR DESCRIPTION
Within librdkafka there appears not to be a mechanism to check the type of connection that is opened on a handle i.e. Producer vs Consumer.

In general the functions available within librdkafka are safe to the use of either producers/consumers as input to functions requiring handles and will error appropriately or work without side effect. However as outlined [here](https://docs.confluent.io/2.0.0/clients/librdkafka/rdkafka_8h.html#a856d7ecba1aa64e5c89ac92b445cdda6) `rd_kafka_memberid` should only be called with a consumer handle and consequently segfaults if invoked otherwise.

The change below creates a mapping on creation of a producer/consumer between the client integer id and the type of handle being created and uses this to check before invocation of the `.kfk.ClientMemberId` function that the handle is valid and will not cause the system to segfault.