### PR TITLE
Fix to mismatch error arising in generation of .kfk.stats.

### DIFF
--- a/kfk.q
+++ b/kfk.q
@@ -143,6 +143,7 @@ statcb:{[j]
     s[`ts]:-10957D+`timestamp$s[`ts]*1000;
     s[`time]:-10957D+`timestamp$1000000000*s[`time]
     ];
+  if[not `cgrp in key s;s[`cgrp]:()];
   .kfk.stats,::enlist s;
   delete from `.kfk.stats where i<count[.kfk.stats]-100;}
 


### PR DESCRIPTION
When starting up a producer and consumer in the same process invocation of the `.kfk.statscb` would result in a mismatch error if the producer was generated first. This is due to the absence of the `cgrp` statistic in producers which is present in consumers. To fix this we need to populate the `cgrp` column of the stats table in the case of both a producer and consumer being generated

This closes #58