### PR TITLE
Update to AssignOffsets function to avoid purge of current assignment

### DIFF
--- a/kfk.c
+++ b/kfk.c
@@ -549,7 +549,7 @@ EXP K1(kfkUnsub){
 }
 
 // https://github.com/edenhill/librdkafka/wiki/Manually-setting-the-consumer-start-offset
-EXP K3(kfkAssignOffsets){
+EXP K3(kfkassignOffsets){
   rd_kafka_t *rk;
   rd_kafka_topic_partition_list_t *t_partition;
   rd_kafka_resp_err_t err;
@@ -559,7 +559,9 @@ EXP K3(kfkAssignOffsets){
     return KNL;
   if(!(rk= clientIndex(x)))
     return KNL;
-  t_partition = rd_kafka_topic_partition_list_new(z->n);
+  // retrieve the current assignment
+  if(KFK_OK != (err=rd_kafka_assignment(rk, &t_partition)))
+    return krr((S)rd_kafka_err2str(err));
   plistoffsetdict(y->s,z,t_partition);
   if(KFK_OK != (err=rd_kafka_assign(rk,t_partition)))
     return krr((S) rd_kafka_err2str(err));

--- a/kfk.q
+++ b/kfk.q
@@ -143,6 +143,7 @@ statcb:{[j]
     s[`ts]:-10957D+`timestamp$s[`ts]*1000;
     s[`time]:-10957D+`timestamp$1000000000*s[`time]
     ];
+  if[not `cgrp in key s;s[`cgrp]:()];
   .kfk.stats,::enlist s;
   delete from `.kfk.stats where i<count[.kfk.stats]-100;}
 

--- a/kfk.q
+++ b/kfk.q
@@ -191,8 +191,12 @@ AssignOffsets:{[cid;top;partoff]
   assignment:.kfk.Assignment[cid];
   toppar:(count[partoff]#top)!key partoff;
   tplist:distinct(,'/)(key;{"j"$value x})@\:toppar;
+  // Find locations where the current assigment needs to be overwritten
   loc:where i.compAssign[cid;tplist];
-  if[count loc;AssignDel[cid;(!) . flip tplist]];
+  if[count loc;
+    currentAssign:(!). flip tplist loc;
+    AssignDel[cid;currentAssign]
+    ];
   assignOffsets[cid;top;partoff]
   }
 

--- a/kfk.q
+++ b/kfk.q
@@ -188,7 +188,6 @@ ClientMemberId:{[cid]
 /* top      = Topic to be subscribed to as a symbol
 /* partoff  = Dictionary mapping integer partition to long offset location
 AssignOffsets:{[cid;top;partoff]
-  assignment:.kfk.Assignment[cid];
   toppar:(count[partoff]#top)!key partoff;
   tplist:distinct(,'/)(key;{"j"$value x})@\:toppar;
   // Find locations where the current assigment needs to be overwritten

--- a/kfk.q
+++ b/kfk.q
@@ -49,8 +49,8 @@ funcs:(
 	(`kfkPositionOffsets;3);
 	  // .kfk.CommittedOffsets[client_id:i;topic:s;partition_offsets:I!J]:partition_offsets
 	(`kfkCommittedOffsets;3);
-	  // .kfk.AssignOffsets[client_id:i;topic:s;partition_offsets:I!J]:()
-	(`kfkAssignOffsets;3);
+	  // .kfk.assignOffsets[client_id:i;topic:s;partition_offsets:I!J]:()
+	(`kfkassignOffsets;3);
           // .kfk.Threadcount[]:i
         (`kfkThreadCount;1);
           // .kfk.VersionSym[]:s
@@ -182,6 +182,19 @@ ClientMemberId:{[cid]
 
 
 // Assignment API logic
+
+// Run assignment of a topic to a particular partition making
+/* cid      = Integer denoting the client ID
+/* top      = Topic to be subscribed to as a symbol
+/* partoff  = Dictionary mapping integer partition to long offset location
+AssignOffsets:{[cid;top;partoff]
+  assignment:.kfk.Assignment[cid];
+  toppar:(count[partoff]#top)!key partoff;
+  tplist:distinct(,'/)(key;{"j"$value x})@\:toppar;
+  loc:where i.compAssign[cid;tplist];
+  if[count loc;AssignDel[cid;(!) . flip tplist]];
+  assignOffsets[cid;top;partoff]
+  }
 
 // Assign a new topic-partition dictionary to be consumed by a designated clientid
 /* cid    = Integer denoting client ID


### PR DESCRIPTION
As outlined in issue #73 the application of the function `.kfk.AssignOffsets` would purge current assignments resulting in the system having no memory of previous offset assignments.

The fix presented in this PR is mindful of a few potential issues.
1. In the application of `kfkassignOffsets` on C side we no longer create a new `topic_partition_list` using `rd_kafka_topic_partition_list_new`  but rather grab the current assignment and augment this.
2. Retrieving the current assignment raises the following issue which need to be mitigated against on q side.
    * Any call to `rd_kafka_assign` need to present a unique topic-partition pair. If the system does not receive a unique combination of these it can segfault.

To ensure that topic-partition pairs are unique application of the function `.kfk.AssignOffsets` will overwrite the current assignment to a topic-partition pair by deleting the current assignment and replacing it with that specified by `.kfk.AssignOffsets`

The following script was used to test the functional addition
```
\l kfk.q

kfk_cfg:(!) . flip(
    (`metadata.broker.list;`localhost:9092);
    (`group.id;`0);
    (`fetch.wait.max.ms;`10);
    (`statistics.interval.ms;`10000)
    );
client:.kfk.Consumer[kfk_cfg];

// Topics to subscribe to
topic1:`test1; topic2:`test2;

-1"Current Assignment";
show .kfk.Assignment[0i]

-1"Add assignment normally to consume from latest";
.kfk.Assign[0i;`test1`test2!0 0];
show .kfk.Assignment[0i]

-1"Assignment following call to AssignOffsets";
.kfk.AssignOffsets[0i;`test2;enlist[0i]!enlist 0];
.kfk.AssignOffsets[0i;`test1;(0 1i)!0 1]
show .kfk.Assignment[0i]
```

With the following resulting output from its execution:
```
Current Assignment
Add assignment normally to consume from latest
topic partition offset metadata
-------------------------------
test1 0         -1001  ""      
test2 0         -1001  ""      
Assignment following call to AssignOffsets
()
topic partition offset metadata
-------------------------------
test2 0         0      ""      
test1 0         0      ""      
test1 1         1      ""  
```

This PR closes #73