### PR TITLE
Allow 'Assign' to take multi topic/part/offsets.

### DIFF
--- a/kfk.c
+++ b/kfk.c
@@ -794,7 +794,15 @@ EXP K2(kfkAssignTopPar){
     return KNL;
   t_partition = rd_kafka_topic_partition_list_new(y->n);
   // topic-partition assignment
-  ptlistadd(y,t_partition);
+  if (KJ==kK(y)[1]->t)
+    ptlistadd(y,t_partition);
+  else{
+    I i;
+    K dk=kK(y)[0],dv=kK(y)[1];
+    S* t=kS(dk);
+    for(i=0;i<dk->n;i++)
+      plistoffsetdict(t[i],kK(dv)[i],t_partition);
+  }
   if(KFK_OK != (err=rd_kafka_assign(rk,t_partition)))
     return krr((S) rd_kafka_err2str(err));
   rd_kafka_topic_partition_list_destroy(t_partition);

--- a/kfk.q
+++ b/kfk.q
@@ -201,14 +201,22 @@ AssignOffsets:{[cid;top;partoff]
   assignOffsets[cid;top;partoff]
   }
 
+i.checkOffsetDict:{[dict]
+  if[not all 99h=type each dict;'"Partition info must be of type  dictionary"];
+  if[not all 6h=type each key each dict;'"Partition dictionary key must of type int"];
+  if[not all 7h=type each value each dict;'"Partition dictionary values must be of type long"];
+  }
 // Assign a new topic-partition dictionary to be consumed by a designated clientid
 /* cid    = Integer denoting client ID
 /* toppar = Symbol!Long dictionary mapping the name of a topic to an associated partition
 Assign:{[cid;toppar]
-  i.checkDict[toppar];
+  if[not 99h=type toppar      ;'"Final parameter must be a dictionary"];
+  if[not 11h=type key toppar  ;'"Dictionary key must of type symbol"];
+  if[2=(7h;0h)?type value toppar;'"Dictionary values must be of type long or a list"];
   // Create a distinct set of topic-partition pairs to assign,
   // non distinct entries cause a segfault
-  toppar:(!). flip distinct(,'/)(key;value)@\:toppar;
+  if[7h=type value toppar;toppar:(!). flip distinct(,'/)(key;value)@\:toppar;]
+  if[0h=type value toppar;i.checkOffsetDict[value toppar];if[(count distinct a)<>count a:raze key[toppar],/:'key each value toppar;'"Topic and Partition mapping not unique"];]
   AssignTopPar[cid;toppar]
   }
 


### PR DESCRIPTION
Should be backwards compatible. Can still take topic/partition, but can now also take topic/partition/offset - so can subscribe to all interested entities in 1 call.
e.g. .kfk.Assign[client;`test1`test2!(((1#0i)!1#10);((1#0i)!1#20))]
