### PR TITLE
wrapper for rd_kafka_query_watermark_offsets. Ref #94

### DIFF
--- a/kfk.c
+++ b/kfk.c
@@ -573,6 +573,24 @@ EXP K1(kfkUnsub){
   return knk(0);
 }
 
+EXP K4(kfkqueryWatermark){
+  rd_kafka_t *rk;
+  rd_kafka_resp_err_t err;
+  J low,high;
+  K w;
+  if(!checkType("isjj",x,y,z,r))
+    return KNL;
+  if(!(rk= clientIndex(x)))
+    return KNL;
+  err= rd_kafka_query_watermark_offsets(rk,y->s,z->j,&low,&high,r->j);
+  if(KFK_OK != err)
+    return krr((S) rd_kafka_err2str(err));
+  w=ktn(KJ,2);
+  kJ(w)[0]=low;
+  kJ(w)[1]=high;
+  return w;
+}
+
 // https://github.com/edenhill/librdkafka/wiki/Manually-setting-the-consumer-start-offset
 EXP K3(kfkassignOffsets){
   rd_kafka_t *rk;

--- a/kfk.c
+++ b/kfk.c
@@ -576,7 +576,7 @@ EXP K1(kfkUnsub){
 EXP K4(kfkqueryWatermark){
   rd_kafka_t *rk;
   rd_kafka_resp_err_t err;
-  J low,high;
+  int64_t low,high;
   K w;
   if(!checkType("isjj",x,y,z,r))
     return KNL;

--- a/kfk.q
+++ b/kfk.q
@@ -50,6 +50,7 @@ funcs:(
 	  // .kfk.CommittedOffsets[client_id:i;topic:s;partition_offsets:I!J]:partition_offsets
 	(`kfkCommittedOffsets;3);
 	  // .kfk.assignOffsets[client_id:i;topic:s;partition_offsets:I!J]:()
+    (`kfkqueryWatermark;4);
 	(`kfkassignOffsets;3);
           // .kfk.Threadcount[]:i
         (`kfkThreadCount;1);

--- a/kfk.q
+++ b/kfk.q
@@ -49,8 +49,9 @@ funcs:(
 	(`kfkPositionOffsets;3);
 	  // .kfk.CommittedOffsets[client_id:i;topic:s;partition_offsets:I!J]:partition_offsets
 	(`kfkCommittedOffsets;3);
-	  // .kfk.assignOffsets[client_id:i;topic:s;partition_offsets:I!J]:()
+	  // .kfk.QueryWatermark[client_id:i:topic:s;partition:j;timeout:j]:_
     (`kfkqueryWatermark;4);
+      // .kfk.AssignOffsets[client_id:i;topic:s;partition_offsets:I!J]:()
 	(`kfkassignOffsets;3);
           // .kfk.Threadcount[]:i
         (`kfkThreadCount;1);


### PR DESCRIPTION

Query broker for low (oldest/beginning) and high (newest/end) offsets for partition.

Returns 2 element long for low/high watermark.
Takes 4 params :
1. cid is client ID (integer)
2. Topic (sym)
3. Partition (long)
4. Timeout ms (long)

e.g. .kfk.queryWatermark[client;`test1;0;1000]
Ref: https://docs.confluent.io/3.3.1/clients/librdkafka/rdkafka_8h.html#a4550ff7d014f08406666124573f70495